### PR TITLE
Deep create log dir

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -44,7 +44,7 @@ fn init_log_file(file: &mut Write) {
 
 impl Logger {
     pub fn new(log_dir: PathBuf) -> Logger {
-        let _ = fs::create_dir(&log_dir);
+        let _ = fs::create_dir_all(&log_dir);
 
         let debug_logs = {
             let mut log_dir = log_dir.clone();


### PR DESCRIPTION
Fix #36 

I think this is not the best approach.  `fs::create_dir_all` may still fails in many scenario, so returning a `Result` may be better.  But that still need more work.