### PR TITLE
Add switch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- `/switch` command added to quickly switch to a different tab using a substring
+
 # 2017/11/12: 0.3.0
 
 - Fixed a bug that caused wrong scrolling in input field after changing nick.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Commands start with `/` character.
 
 - `/join <channel>`: Join to a channel
 
-- `/close`: close the current tab. Leaves the channel if the current tab is a
+- `/close`: Close the current tab. Leaves the channel if the current tab is a
   channel. Leaves the server if the tab is a server.
 
 - `/connect <hostname>:<port>`: Connect to a server. Uses `defaults` in the
@@ -240,6 +240,8 @@ Commands start with `/` character.
 - `/reload`: Reload configuration
 
 - `/clear`: Clears tab contents
+
+- `/switch <string>`: Switch to the first tab which has the given string in the name.
 
 ## Development
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,6 +441,8 @@ impl<'poll> Tiny<'poll> {
             }
         } else if words[0] == "clear" {
             self.tui.clear(&src.to_target());
+        } else if words[0] == "switch" && words.len() == 2{
+            self.tui.switch(words[1]);
         } else if words[0] == "ignore" {
             match src {
                 MsgSource::Serv { serv_name } => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -282,4 +282,8 @@ impl TUI {
     pub fn clear(&mut self, target: &MsgTarget) {
         self.ui.clear(target);
     }
+
+    pub fn switch(&mut self, string: &str){
+        self.ui.switch(string)
+    }
 }

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -523,6 +523,35 @@ impl Tabbed {
         self.tabs[self.active_idx].set_style(TabStyle::Normal);
     }
 
+    pub fn switch(&mut self, string: &str) {
+        let mut next_idx = self.active_idx;
+        for (tab_idx,tab) in self.tabs.iter().enumerate() {
+            match tab.src {
+                MsgSource::Serv { ref serv_name } => {
+                    if serv_name.contains(string) {
+                        next_idx = tab_idx;
+                        break
+                    }
+                },
+                MsgSource::Chan { ref chan_name, .. } => {
+                    if chan_name.contains(string) {
+                        next_idx = tab_idx;
+                        break
+                    }
+                },
+                MsgSource::User { ref nick, .. } => {
+                    if nick.contains(string) {
+                        next_idx = tab_idx;
+                        break
+                    }
+                }
+            }
+        }
+        if next_idx != self.active_idx {
+            self.select_tab(next_idx);
+        }
+    }
+
     fn next_tab_(&mut self) {
         if self.active_idx == self.tabs.len() - 1 {
             self.active_idx = 0;


### PR DESCRIPTION
This is something I use personally.

You can now use `/switch` command to switch to the window with a
specific substring.

> Don't know if its he right command name ( `goto` may be better )

Usage:

```
/switch freenode
```