### PR TITLE
Handle Del key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - `/switch` command added to quickly switch to a different tab using a substring
+- Handle 'Del' key
 
 # 2017/11/12: 0.3.0
 

--- a/src/tui/text_field.rs
+++ b/src/tui/text_field.rs
@@ -169,6 +169,14 @@ impl TextField {
                 WidgetRet::KeyHandled
             }
 
+            Key::Del => {
+                if self.cursor < self.line_len() {
+                    self.modify();
+                    self.buffer.remove(self.cursor as usize);
+                }
+                WidgetRet::KeyHandled
+            }
+
             Key::Ctrl(ch) =>
                 if ch == 'a' {
                     self.move_cursor(0);

--- a/term_input/src/lib.rs
+++ b/term_input/src/lib.rs
@@ -33,6 +33,7 @@ pub enum Key {
     Char(char),
     Ctrl(char),
     CtrlArrow(Arrow),
+    Del,
     End,
     Enter,
     Esc,
@@ -101,6 +102,7 @@ static XTERM_CTRL_ARROW_DOWN : [u8; 6] = [27, 91, 49, 59, 53, 66];
 static XTERM_CTRL_ARROW_LEFT : [u8; 6] = [27, 91, 49, 59, 53, 68];
 static XTERM_CTRL_ARROW_RIGHT: [u8; 6] = [27, 91, 49, 59, 53, 67];
 static XTERM_CTRL_ARROW_UP   : [u8; 6] = [27, 91, 49, 59, 53, 65];
+static XTERM_DEL             : [u8; 4] = [27, 91, 51, 126];
 static XTERM_PAGE_DOWN       : [u8; 4] = [27, 91, 54, 126];
 static XTERM_PAGE_UP         : [u8; 4] = [27, 91, 53, 126];
 static XTERM_SHIFT_UP        : [u8; 6] = [27, 91, 49, 59, 50, 65];
@@ -114,7 +116,7 @@ static XTERM_END             : [u8; 3] = [27, 91, 70];
 static XTERM_HOME_2          : [u8; 3] = [27, 79, 72];
 static XTERM_END_2           : [u8; 3] = [27, 79, 70];
 
-static XTERM_KEY_SEQS : [(&'static [u8], Event); 26] =
+static XTERM_KEY_SEQS : [(&'static [u8], Event); 27] =
     [ (&XTERM_ALT_ARROW_DOWN,  Event::Key(Key::AltArrow(Arrow::Down))),
       (&XTERM_ALT_ARROW_LEFT,  Event::Key(Key::AltArrow(Arrow::Left))),
       (&XTERM_ALT_ARROW_RIGHT, Event::Key(Key::AltArrow(Arrow::Right))),
@@ -131,6 +133,7 @@ static XTERM_KEY_SEQS : [(&'static [u8], Event); 26] =
       (&XTERM_CTRL_ARROW_LEFT, Event::Key(Key::CtrlArrow(Arrow::Left))),
       (&XTERM_CTRL_ARROW_RIGHT,Event::Key(Key::CtrlArrow(Arrow::Right))),
       (&XTERM_CTRL_ARROW_UP,   Event::Key(Key::CtrlArrow(Arrow::Up))),
+      (&XTERM_DEL,             Event::Key(Key::Del)),
       (&XTERM_PAGE_DOWN,       Event::Key(Key::PageDown)),
       (&XTERM_PAGE_UP,         Event::Key(Key::PageUp)),
       (&XTERM_SHIFT_UP,        Event::Key(Key::ShiftUp)),


### PR DESCRIPTION
Fix #41 

@osa1 metioned in the issue
> Map byte string [ 27, 91, 80 ] to to Del

But I found that it doesn't work.  What really works is [27, 91, 51, 126].  Yes I am in TERM=xterm-256color.

```
sh-4.4$ TERM=xterm tput kdch1 | sed -n l
\033[3~$
```
Which represent [27, 92, 91, 126] (ignore the $)

Is [ 27, 91, 80 ] really necessary in some other computer?  If yes I will add it as `XTERM_DEL_2`.