### PR TITLE
Desktop notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libdbus-1-dev ; fi
+
 language: rust
 
 rust:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- `/notify` command to enable and disable desktop notifications.
 - `/switch` command added to quickly switch to a different tab using a
   substring of the tab name.
 - `Del` key is now handled. It deletes character under the cursor.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ take_mut = "0.2.0"
 term_input = "0.1.3"
 termbox_simple = "0.2.0"
 time = "0.1"
+notify-rust = "3"
 
 [dev-dependencies]
 quickcheck = "0.3"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ libraries. See [rust-openssl's
 README](https://github.com/sfackler/rust-openssl#linux) for instructions on
 installing them.
 
+##### Dependencies
+
+* OpenSSL or LibreSSL
+* libdbus [Linux only]
+
 tiny is tested on Linux and OSX.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ Commands start with `/` character.
   name will have `[i]` added to the end to show that it is enabled. Running
   this command in a server tab applies it to all channels of that server.
 
+- `/notify [off/mentions/messages]`: Enable and disable desktop notifications.
+  You can use `/notify` command without any arguments to see the current mode. 
+  Running this command in a server tab applies it to all channels of that server.
+
 ## Development
 
 tiny is in early stages of development. Some of features that you might think

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -9,6 +9,8 @@ use tui::{MsgTarget, Timestamp};
 use utils;
 use serde::de::{Deserializer, Visitor};
 
+use notifier::NotifyFor;
+
 pub struct Cmd {
     /// Command name. E.g. if this is `"cmd"`, `/cmd ...` will call this command.
     pub name: &'static str,
@@ -588,9 +590,15 @@ fn notify(args: &str, _: &Poll, tiny: &mut Tiny, src: MsgSource) {
         );
     }
     else {
+        let mut notify_for = NotifyFor::Off;
+        if words[0] == "messages" {
+            notify_for = NotifyFor::Messages;
+        } else if words[0] == "mentions" {
+            notify_for = NotifyFor::Mentions;
+        }
         match src {
             MsgSource::Serv { serv_name } => {
-                tiny.tui.notify(&words[0], &MsgTarget::AllServTabs {
+                tiny.tui.notify(notify_for, &MsgTarget::AllServTabs {
                     serv_name: &serv_name,
                 });
             }
@@ -598,13 +606,13 @@ fn notify(args: &str, _: &Poll, tiny: &mut Tiny, src: MsgSource) {
                 serv_name,
                 chan_name,
             } => {
-                tiny.tui.notify(&words[0], &MsgTarget::Chan {
+                tiny.tui.notify(notify_for, &MsgTarget::Chan {
                     serv_name: &serv_name,
                     chan_name: &chan_name,
                 });
             }
             MsgSource::User { serv_name, nick } => {
-                tiny.tui.notify(&words[0], &MsgTarget::User {
+                tiny.tui.notify(notify_for, &MsgTarget::User {
                     serv_name: &serv_name,
                     nick: &nick,
                 });

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -593,8 +593,21 @@ fn notify(args: &str, _: &Poll, tiny: &mut Tiny, src: MsgSource) {
         let mut notify_for = NotifyFor::Off;
         if words[0] == "messages" {
             notify_for = NotifyFor::Messages;
+            tiny.tui.add_client_notify_msg(
+                "Notifications enabled for all messages",
+                &MsgTarget::CurrentTab,
+            );
         } else if words[0] == "mentions" {
             notify_for = NotifyFor::Mentions;
+            tiny.tui.add_client_notify_msg(
+                "Notifications enabled for mentions",
+                &MsgTarget::CurrentTab,
+            );
+        } else {
+            tiny.tui.add_client_notify_msg(
+                "Notifications turned off",
+                &MsgTarget::CurrentTab,
+            );
         }
         match src {
             MsgSource::Serv { serv_name } => {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -125,7 +125,7 @@ impl<'de> Deserialize<'de> for AutoCmd {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static CMDS: [&'static Cmd; 13] = [
+static CMDS: [&'static Cmd; 14] = [
     &AWAY_CMD,
     &CLEAR_CMD,
     &CLOSE_CMD,
@@ -139,6 +139,7 @@ static CMDS: [&'static Cmd; 13] = [
     &NICK_CMD,
     &RELOAD_CMD,
     &SWITCH_CMD,
+    &NOTIFY_CMD,
 ];
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -569,6 +570,47 @@ fn switch(args: &str, _: &Poll, tiny: &mut Tiny, _: MsgSource) {
         );
     }
     tiny.tui.switch(words[0]);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static NOTIFY_CMD: Cmd = Cmd {
+    name: "notify",
+    cmd_fn: notify,
+};
+
+fn notify(args: &str, _: &Poll, tiny: &mut Tiny, src: MsgSource) {
+    let words: Vec<&str> = args.split_whitespace().collect();
+    if !(words.len() == 1  && ["off", "mentions", "messages"].contains(&words[0])) {
+        return tiny.tui.add_client_err_msg(
+            "/notify usage: /notify [off/mentions/messages]",
+            &MsgTarget::CurrentTab,
+        );
+    }
+    else {
+        match src {
+            MsgSource::Serv { serv_name } => {
+                tiny.tui.notify(&words[0], &MsgTarget::AllServTabs {
+                    serv_name: &serv_name,
+                });
+            }
+            MsgSource::Chan {
+                serv_name,
+                chan_name,
+            } => {
+                tiny.tui.notify(&words[0], &MsgTarget::Chan {
+                    serv_name: &serv_name,
+                    chan_name: &chan_name,
+                });
+            }
+            MsgSource::User { serv_name, nick } => {
+                tiny.tui.notify(&words[0], &MsgTarget::User {
+                    serv_name: &serv_name,
+                    nick: &nick,
+                });
+            }
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -583,7 +583,10 @@ static NOTIFY_CMD: Cmd = Cmd {
 
 fn notify(args: &str, _: &Poll, tiny: &mut Tiny, src: MsgSource) {
     let words: Vec<&str> = args.split_whitespace().collect();
-    if !(words.len() == 1  && ["off", "mentions", "messages"].contains(&words[0])) {
+    if words.len() == 0 {
+        tiny.tui.show_notify_mode(&MsgTarget::CurrentTab);
+    }
+    else if !(words.len() == 1  && ["off", "mentions", "messages"].contains(&words[0])) {
         return tiny.tui.add_client_err_msg(
             "/notify usage: /notify [off/mentions/messages]",
             &MsgTarget::CurrentTab,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod conn;
 mod logger;
 mod stream;
 mod wire;
+mod notifier;
 pub mod config;
 pub mod trie;
 pub mod tui;

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -34,37 +34,24 @@ impl Notifier {
         sender: &str,
         msg: &str,
         target: &MsgTarget,
-        nick: Option<&str>,
+        nick: &str,
         mention: bool,
     ) {
         match *target {
             MsgTarget::Chan { chan_name, .. } => {
                 if self.notify_for == "messages" || (self.notify_for == "mentions" && mention) {
-                    match nick {
-                        Some(nick_) => {
-                            if nick_ != sender {
-                                self.notify(
-                                    &format!("{} in {}", sender, chan_name),
-                                    &format!("{}", msg),
-                                )
-                            }
-                        }
-                        None => {}  // Do we have to do this?
+                    if nick != sender {
+                        self.notify(&format!("{} in {}", sender, chan_name), &format!("{}", msg))
                     }
                 }
             }
             MsgTarget::User { nick: ref nick_sender, .. } => {
                 if self.notify_for != "off" {
-                    match nick {
-                        Some(nick_) => {
-                            if nick_ != sender {
-                                self.notify(
-                                    &format!("{} sent a private message", nick_sender),
-                                    &format!("{}", msg),
-                                )
-                            }
-                        }
-                        None => {}
+                    if nick != sender {
+                        self.notify(
+                            &format!("{} sent a private message", nick_sender),
+                            &format!("{}", msg),
+                        )
                     }
                 }
             }

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -10,7 +10,7 @@ pub enum NotifyFor { Off, Mentions, Messages }
 
 // Destktop notification handler
 pub struct Notifier {
-    notify_for: NotifyFor,
+    pub notify_for: NotifyFor,
 }
 
 impl Notifier {
@@ -20,10 +20,6 @@ impl Notifier {
 
     pub fn set_notify_for(&mut self, notify_for_: NotifyFor) {
         self.notify_for = notify_for_;
-    }
-
-    pub fn get_notify_for(&mut self) -> NotifyFor {
-        return self.notify_for;
     }
 
     fn notify(&mut self, summary: &str, body: &str) {

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -35,13 +35,11 @@ impl Notifier {
         msg: &str,
         target: &MsgTarget,
         nick: Option<&str>,
+        mention: bool,
     ) {
         match *target {
-            // MsgTarget::Server { serv_name } => {
-            //     self.notify(&format!("{} in {}", sender, serv_name), &format!("{}", msg))
-            // },
             MsgTarget::Chan { chan_name, .. } => {
-                if self.notify_for != "off" {
+                if self.notify_for == "messages" || (self.notify_for == "mentions" && mention) {
                     match nick {
                         Some(nick_) => {
                             if nick_ != sender {
@@ -56,16 +54,18 @@ impl Notifier {
                 }
             }
             MsgTarget::User { nick: ref nick_sender, .. } => {
-                match nick {
-                    Some(nick_) => {
-                        if nick_ != sender {
-                            self.notify(
-                                &format!("{} sent a private message", nick_sender),
-                                &format!("{}", msg),
-                            )
+                if self.notify_for != "off" {
+                    match nick {
+                        Some(nick_) => {
+                            if nick_ != sender {
+                                self.notify(
+                                    &format!("{} sent a private message", nick_sender),
+                                    &format!("{}", msg),
+                                )
+                            }
                         }
+                        None => {}
                     }
-                    None => {}
                 }
             }
             _ => {}

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -1,0 +1,74 @@
+extern crate notify_rust;
+
+pub use tui::messaging::Timestamp;
+use tui::MsgTarget;
+
+use self::notify_rust::Notification;
+
+
+// Destktop notification handler
+pub struct Notifier {
+    // [off,mentions,messages]
+    notify_for: String,
+}
+
+impl Notifier {
+    pub fn init(notify_for_: &str) -> Notifier {
+        return Notifier { notify_for: notify_for_.to_string() };
+    }
+
+    pub fn set_notify_for(&mut self, notify_for_: &str) {
+        self.notify_for = notify_for_.to_string();
+    }
+
+    fn notify(&mut self, summary: &str, body: &str) {
+        Notification::new()
+            .summary(summary)
+            .body(body)
+            .show()
+            .unwrap();
+    }
+
+    pub fn notify_privmsg(
+        &mut self,
+        sender: &str,
+        msg: &str,
+        target: &MsgTarget,
+        nick: Option<&str>,
+    ) {
+        match *target {
+            // MsgTarget::Server { serv_name } => {
+            //     self.notify(&format!("{} in {}", sender, serv_name), &format!("{}", msg))
+            // },
+            MsgTarget::Chan { chan_name, .. } => {
+                if self.notify_for != "off" {
+                    match nick {
+                        Some(nick_) => {
+                            if nick_ != sender {
+                                self.notify(
+                                    &format!("{} in {}", sender, chan_name),
+                                    &format!("{}", msg),
+                                )
+                            }
+                        }
+                        None => {}  // Do we have to do this?
+                    }
+                }
+            }
+            MsgTarget::User { nick: ref nick_sender, .. } => {
+                match nick {
+                    Some(nick_) => {
+                        if nick_ != sender {
+                            self.notify(
+                                &format!("{} sent a private message", nick_sender),
+                                &format!("{}", msg),
+                            )
+                        }
+                    }
+                    None => {}
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -5,20 +5,21 @@ use tui::MsgTarget;
 
 use self::notify_rust::Notification;
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum NotifyFor { Off, Mentions, Messages }
 
 // Destktop notification handler
 pub struct Notifier {
-    // [off,mentions,messages]
-    notify_for: String,
+    notify_for: NotifyFor,
 }
 
 impl Notifier {
-    pub fn init(notify_for_: &str) -> Notifier {
-        return Notifier { notify_for: notify_for_.to_string() };
+    pub fn init(notify_for_: NotifyFor) -> Notifier {
+        return Notifier { notify_for: notify_for_ };
     }
 
-    pub fn set_notify_for(&mut self, notify_for_: &str) {
-        self.notify_for = notify_for_.to_string();
+    pub fn set_notify_for(&mut self, notify_for_: NotifyFor) {
+        self.notify_for = notify_for_;
     }
 
     fn notify(&mut self, summary: &str, body: &str) {
@@ -39,14 +40,14 @@ impl Notifier {
     ) {
         match *target {
             MsgTarget::Chan { chan_name, .. } => {
-                if self.notify_for == "messages" || (self.notify_for == "mentions" && mention) {
+                if self.notify_for == NotifyFor::Messages || (self.notify_for == NotifyFor::Mentions && mention) {
                     if nick != sender {
                         self.notify(&format!("{} in {}", sender, chan_name), &format!("{}", msg))
                     }
                 }
             }
             MsgTarget::User { nick: ref nick_sender, .. } => {
-                if self.notify_for != "off" {
+                if self.notify_for != NotifyFor::Off {
                     if nick != sender {
                         self.notify(
                             &format!("{} sent a private message", nick_sender),

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -22,6 +22,10 @@ impl Notifier {
         self.notify_for = notify_for_;
     }
 
+    pub fn get_notify_for(&mut self) -> NotifyFor {
+        return self.notify_for;
+    }
+
     fn notify(&mut self, summary: &str, body: &str) {
         Notification::new()
             .summary(summary)

--- a/src/tui/messaging.rs
+++ b/src/tui/messaging.rs
@@ -112,8 +112,10 @@ impl MessagingUI {
 
     fn draw_input_field(&self, tb: &mut Termbox, colors: &Colors, pos_x: i32, pos_y: i32) {
         match self.exit_dialogue {
-            Some(ref exit_dialogue) => exit_dialogue.draw(tb, colors, pos_x, pos_y),
-            None => self.input_field.draw(tb, colors, pos_x, pos_y),
+            Some(ref exit_dialogue) =>
+                exit_dialogue.draw(tb, colors, pos_x, pos_y),
+            None =>
+                self.input_field.draw(tb, colors, pos_x, pos_y),
         }
     }
 
@@ -269,9 +271,8 @@ impl MessagingUI {
     pub fn show_topic(&mut self, topic: &str, ts: Timestamp) {
         self.add_timestamp(ts);
 
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::Topic),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::Topic));
         self.msg_area.add_text(topic);
 
         self.msg_area.flush_line();
@@ -280,9 +281,8 @@ impl MessagingUI {
     pub fn add_client_err_msg(&mut self, msg: &str) {
         self.reset_activity_line();
 
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::ErrMsg),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::ErrMsg));
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
     }
@@ -290,9 +290,8 @@ impl MessagingUI {
     pub fn add_client_notify_msg(&mut self, msg: &str) {
         self.reset_activity_line();
 
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::Faded),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::Faded));
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
         self.reset_activity_line();
@@ -301,9 +300,8 @@ impl MessagingUI {
     pub fn add_client_msg(&mut self, msg: &str) {
         self.reset_activity_line();
 
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::UserMsg),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
         self.reset_activity_line();
@@ -321,9 +319,8 @@ impl MessagingUI {
         self.add_timestamp(ts);
 
         if ctcp_action {
-            self.msg_area.set_style(
-                SegStyle::SchemeStyle(SchemeStyle::UserMsg),
-            );
+            self.msg_area
+                .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
             self.msg_area.add_text("** ");
         }
 
@@ -334,9 +331,8 @@ impl MessagingUI {
             self.msg_area.add_text(sender);
         }
 
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::UserMsg),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
 
         if !ctcp_action {
             self.msg_area.add_char(':');
@@ -344,9 +340,8 @@ impl MessagingUI {
         self.msg_area.add_char(' ');
 
         if highlight {
-            self.msg_area.set_style(
-                SegStyle::SchemeStyle(SchemeStyle::Highlight),
-            );
+            self.msg_area
+                .set_style(SegStyle::SchemeStyle(SchemeStyle::Highlight));
         }
 
         self.msg_area.add_text(msg);
@@ -357,9 +352,8 @@ impl MessagingUI {
         self.reset_activity_line();
 
         self.add_timestamp(ts);
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::UserMsg),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
     }
@@ -368,9 +362,8 @@ impl MessagingUI {
         self.reset_activity_line();
 
         self.add_timestamp(ts);
-        self.msg_area.set_style(
-            SegStyle::SchemeStyle(SchemeStyle::ErrMsg),
-        );
+        self.msg_area
+            .set_style(SegStyle::SchemeStyle(SchemeStyle::ErrMsg));
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
     }
@@ -445,7 +438,7 @@ impl MessagingUI {
         }
     }
 
-    pub fn get_ignore_state(&self) -> bool {
+    pub fn get_ignore_state(&self) -> bool{
         return self.show_status;
     }
 

--- a/src/tui/messaging.rs
+++ b/src/tui/messaging.rs
@@ -112,10 +112,8 @@ impl MessagingUI {
 
     fn draw_input_field(&self, tb: &mut Termbox, colors: &Colors, pos_x: i32, pos_y: i32) {
         match self.exit_dialogue {
-            Some(ref exit_dialogue) =>
-                exit_dialogue.draw(tb, colors, pos_x, pos_y),
-            None =>
-                self.input_field.draw(tb, colors, pos_x, pos_y),
+            Some(ref exit_dialogue) => exit_dialogue.draw(tb, colors, pos_x, pos_y),
+            None => self.input_field.draw(tb, colors, pos_x, pos_y),
         }
     }
 
@@ -271,8 +269,9 @@ impl MessagingUI {
     pub fn show_topic(&mut self, topic: &str, ts: Timestamp) {
         self.add_timestamp(ts);
 
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::Topic));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::Topic),
+        );
         self.msg_area.add_text(topic);
 
         self.msg_area.flush_line();
@@ -281,8 +280,9 @@ impl MessagingUI {
     pub fn add_client_err_msg(&mut self, msg: &str) {
         self.reset_activity_line();
 
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::ErrMsg));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::ErrMsg),
+        );
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
     }
@@ -290,8 +290,9 @@ impl MessagingUI {
     pub fn add_client_notify_msg(&mut self, msg: &str) {
         self.reset_activity_line();
 
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::Faded));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::Faded),
+        );
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
         self.reset_activity_line();
@@ -300,8 +301,9 @@ impl MessagingUI {
     pub fn add_client_msg(&mut self, msg: &str) {
         self.reset_activity_line();
 
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::UserMsg),
+        );
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
         self.reset_activity_line();
@@ -319,8 +321,9 @@ impl MessagingUI {
         self.add_timestamp(ts);
 
         if ctcp_action {
-            self.msg_area
-                .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
+            self.msg_area.set_style(
+                SegStyle::SchemeStyle(SchemeStyle::UserMsg),
+            );
             self.msg_area.add_text("** ");
         }
 
@@ -331,8 +334,9 @@ impl MessagingUI {
             self.msg_area.add_text(sender);
         }
 
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::UserMsg),
+        );
 
         if !ctcp_action {
             self.msg_area.add_char(':');
@@ -340,8 +344,9 @@ impl MessagingUI {
         self.msg_area.add_char(' ');
 
         if highlight {
-            self.msg_area
-                .set_style(SegStyle::SchemeStyle(SchemeStyle::Highlight));
+            self.msg_area.set_style(
+                SegStyle::SchemeStyle(SchemeStyle::Highlight),
+            );
         }
 
         self.msg_area.add_text(msg);
@@ -352,8 +357,9 @@ impl MessagingUI {
         self.reset_activity_line();
 
         self.add_timestamp(ts);
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::UserMsg));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::UserMsg),
+        );
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
     }
@@ -362,8 +368,9 @@ impl MessagingUI {
         self.reset_activity_line();
 
         self.add_timestamp(ts);
-        self.msg_area
-            .set_style(SegStyle::SchemeStyle(SchemeStyle::ErrMsg));
+        self.msg_area.set_style(
+            SegStyle::SchemeStyle(SchemeStyle::ErrMsg),
+        );
         self.msg_area.add_text(msg);
         self.msg_area.flush_line();
     }
@@ -438,7 +445,7 @@ impl MessagingUI {
         }
     }
 
-    pub fn get_ignore_state(&self) -> bool{
+    pub fn get_ignore_state(&self) -> bool {
         return self.show_status;
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -277,6 +277,10 @@ impl TUI {
         self.ui.toggle_ignore(target);
     }
 
+    pub fn notify(&mut self, notify_for: &str, target: &MsgTarget) {
+        self.ui.notify(notify_for, target);
+    }
+
     pub fn remove_nick(&mut self, nick: &str, ts: Option<Timestamp>, target: &MsgTarget) {
         self.ui.remove_nick(nick, ts, target);
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -289,6 +289,10 @@ impl TUI {
         self.ui.notify(notify_for, target);
     }
 
+    pub fn show_notify_mode(&mut self, target: &MsgTarget){
+        self.ui.show_notify_mode(target);
+    }
+
     pub fn remove_nick(&mut self, nick: &str, ts: Option<Timestamp>, target: &MsgTarget) {
         self.ui.remove_nick(nick, ts, target);
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -17,6 +17,8 @@ use term_input::{Event, Key};
 use termbox_simple::{OutputMode, Termbox};
 use trie::Trie;
 
+use notifier::NotifyFor;
+
 pub struct TUI {
     /// Termbox instance
     termbox: Termbox,
@@ -277,7 +279,7 @@ impl TUI {
         self.ui.toggle_ignore(target);
     }
 
-    pub fn notify(&mut self, notify_for: &str, target: &MsgTarget) {
+    pub fn notify(&mut self, notify_for: NotifyFor, target: &MsgTarget) {
         self.ui.notify(notify_for, target);
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -219,6 +219,12 @@ impl TUI {
         self.ui.add_client_err_msg(msg, target);
     }
 
+    /// An notify message coming from Tiny, usually shows a response of a command
+    /// Eg: "Notifications enabled"
+    pub fn add_client_notify_msg(&mut self, msg: &str, target: &MsgTarget) {
+        self.ui.add_client_notify_msg(msg, target);
+    }
+
     /// A message from client, usually just to indidate progress, e.g.
     /// "Connecting...". Not timestamed and not logged.
     pub fn add_client_msg(&mut self, msg: &str, target: &MsgTarget) {

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -9,6 +9,8 @@ use tui::messaging::Timestamp;
 use tui::MsgTarget;
 use tui::widget::WidgetRet;
 
+use notifier::Notifier;
+
 const LEFT_ARROW: char = '<';
 const RIGHT_ARROW: char = '>';
 
@@ -29,6 +31,7 @@ struct Tab {
     style: TabStyle,
     /// Alt-character to use to switch to this tab.
     switch: Option<char>,
+    notifier: Notifier,
 }
 
 // NOTE: Keep the variants sorted in increasing significance, to avoid updating
@@ -225,6 +228,7 @@ impl Tabbed {
                 src,
                 style: TabStyle::Normal,
                 switch,
+                notifier: Notifier::init("messages")
             },
         );
     }
@@ -930,6 +934,7 @@ impl Tabbed {
         ctcp_action: bool,
     ) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
+            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick());
             tab.widget.add_privmsg(sender, msg, ts, false, ctcp_action);
         });
     }
@@ -943,6 +948,7 @@ impl Tabbed {
         ctcp_action: bool,
     ) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
+            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick());
             tab.widget.add_privmsg(sender, msg, ts, true, ctcp_action);
         });
     }

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -934,8 +934,11 @@ impl Tabbed {
         ctcp_action: bool,
     ) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
-            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick(), false);
             tab.widget.add_privmsg(sender, msg, ts, false, ctcp_action);
+            let nick = tab.widget.get_nick();
+            if let Some(nick_) = nick {
+                tab.notifier.notify_privmsg(sender, msg, target, nick_, false);
+            }
         });
     }
 
@@ -948,8 +951,11 @@ impl Tabbed {
         ctcp_action: bool,
     ) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
-            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick(), true);
             tab.widget.add_privmsg(sender, msg, ts, true, ctcp_action);
+            let nick = tab.widget.get_nick();
+            if let Some(nick_) = nick {
+                tab.notifier.notify_privmsg(sender, msg, target, nick_, true);
+            }
         });
     }
 

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -228,7 +228,7 @@ impl Tabbed {
                 src,
                 style: TabStyle::Normal,
                 switch,
-                notifier: Notifier::init("messages")
+                notifier: Notifier::init("mentions")
             },
         );
     }
@@ -934,7 +934,7 @@ impl Tabbed {
         ctcp_action: bool,
     ) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
-            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick());
+            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick(), false);
             tab.widget.add_privmsg(sender, msg, ts, false, ctcp_action);
         });
     }
@@ -948,7 +948,7 @@ impl Tabbed {
         ctcp_action: bool,
     ) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
-            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick());
+            tab.notifier.notify_privmsg(sender, msg, target, tab.widget.get_nick(), true);
             tab.widget.add_privmsg(sender, msg, ts, true, ctcp_action);
         });
     }
@@ -1036,6 +1036,12 @@ impl Tabbed {
                 tab.widget.set_ignore(None);
             });
         }
+    }
+
+    pub fn notify(&mut self, notify_for: &str, target: &MsgTarget){
+        self.apply_to_target(target, &|tab: &mut Tab, _| {
+            tab.notifier.set_notify_for(notify_for);
+        });
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -1057,6 +1057,22 @@ impl Tabbed {
         });
     }
 
+    pub fn show_notify_mode(&mut self, target: &MsgTarget){
+        self.apply_to_target(target, &|tab: &mut Tab, _| {
+            let notify_for = tab.notifier.get_notify_for();
+            if notify_for == NotifyFor::Off {
+                tab.widget.add_client_notify_msg("Notifications are off");
+            }
+            else if notify_for == NotifyFor::Mentions {
+                tab.widget.add_client_notify_msg("Notifications enabled for mentions");
+            }
+            else if notify_for == NotifyFor::Messages {
+                tab.widget.add_client_notify_msg("Notifications enabled for all messages");
+            }
+        });
+    }
+
+
     ////////////////////////////////////////////////////////////////////////////
     // Helpers
 

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -920,6 +920,12 @@ impl Tabbed {
         });
     }
 
+    pub fn add_client_notify_msg(&mut self, msg: &str, target: &MsgTarget) {
+        self.apply_to_target(target, &|tab: &mut Tab, _| {
+            tab.widget.add_client_notify_msg(msg);
+        });
+    }
+
     pub fn add_client_msg(&mut self, msg: &str, target: &MsgTarget) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
             tab.widget.add_client_msg(msg);

--- a/src/tui/tabbed.rs
+++ b/src/tui/tabbed.rs
@@ -10,6 +10,7 @@ use tui::MsgTarget;
 use tui::widget::WidgetRet;
 
 use notifier::Notifier;
+use notifier::NotifyFor;
 
 const LEFT_ARROW: char = '<';
 const RIGHT_ARROW: char = '>';
@@ -228,7 +229,7 @@ impl Tabbed {
                 src,
                 style: TabStyle::Normal,
                 switch,
-                notifier: Notifier::init("mentions")
+                notifier: Notifier::init(NotifyFor::Mentions)
             },
         );
     }
@@ -1044,7 +1045,7 @@ impl Tabbed {
         }
     }
 
-    pub fn notify(&mut self, notify_for: &str, target: &MsgTarget){
+    pub fn notify(&mut self, notify_for: NotifyFor, target: &MsgTarget){
         self.apply_to_target(target, &|tab: &mut Tab, _| {
             tab.notifier.set_notify_for(notify_for);
         });


### PR DESCRIPTION
for #72 

> By default notifications is set to `mentions`

- [x] Notifications on messages
- [x] `/notify [off/mentions/messages]` command to notify mode
- [ ] config file option for notify setting on a per server basis ( is this necessary? )
  
  