### PR TITLE
Add `--config` flag to specify config file location

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -540,7 +540,7 @@ static RELOAD_CMD: Cmd = Cmd {
 };
 
 fn reload(_: &str, _: &Poll, tiny: &mut Tiny, _: MsgSource) {
-    match config::parse_config(config::get_config_path()) {
+    match config::parse_config(tiny.config_path.clone()) {
         Ok(config::Config { colors, .. }) =>
             tiny.tui.set_colors(colors),
         Err(err) => {

--- a/src/cmd_line_args.rs
+++ b/src/cmd_line_args.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+pub struct CmdLineArgs {
+    /// Servers to connect to
+    pub servers: Vec<String>,
+
+    /// Path to config file
+    pub config_path: Option<PathBuf>,
+}
+
+pub fn parse_cmd_line_args(args: Vec<String>) -> CmdLineArgs {
+    let mut parsed_args = CmdLineArgs {
+        servers: Vec::new(),
+        config_path: None,
+    };
+
+    if args.len() >= 2 {
+        let mut i = 1;
+        while i < args.len() {
+            if args[i] == "--config" {
+                if i + 1 < args.len() {
+                    parsed_args.config_path = Some(PathBuf::from(args[i+1].clone()));
+                }
+                i += 1;
+            } else {
+                parsed_args.servers.push(args[i].clone());
+            }
+            i += 1;
+        }
+    }
+
+    parsed_args
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ pub struct Config {
     pub log_dir: String,
 }
 
-pub fn get_config_path() -> PathBuf {
+pub fn get_default_config_path() -> PathBuf {
     let mut config_path = home_dir().unwrap();
     config_path.push(".tinyrc.yml");
     config_path
@@ -101,8 +101,7 @@ fn parse_config_str(contents: &str) -> Result<Config, serde_yaml::Error> {
     Ok(cfg)
 }
 
-pub fn generate_default_config() {
-    let config_path = get_config_path();
+pub fn generate_default_config(config_path: PathBuf) {
     {
         let mut file = File::create(&config_path).unwrap();
         file.write_all(get_default_config_yaml().as_bytes())


### PR DESCRIPTION
I added DIY command line arg parsing, as it seemed the simplest option given that we only have 1 flag. I also added a `config_path` field to the `Tiny` struct so that the reload command works correctly. I had a little trouble with the borrow checker so some of the code may not be optimal (i.e. the `clone()`s).