### PR TITLE
SASL authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - tiny can now show desktop notifications for incoming messages. See README for
   notification options. Defaults: show notifications for mentions in channels
   and all private messages.
+- Support SASL `PLAIN` authenication.  Add a section of `sasl_auth` in
+  `.tinyrc.yml` to use.
 
 # 2017/11/12: 0.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ take_mut = "0.2.0"
 term_input = "0.1.3"
 termbox_simple = "0.2.0"
 time = "0.1"
+base64 = "0.6.0"
 
 [dev-dependencies]
 quickcheck = "0.3"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -331,7 +331,7 @@ fn connect_<'a, 'b>(serv_addr: &str, pass: Option<&str>, poll: &'b Poll, tiny: &
             nicks: tiny.defaults.nicks.clone(),
             auto_cmds: tiny.defaults.auto_cmds.clone(),
             join: tiny.defaults.join.clone(),
-            auth: None,
+            sasl_auth: None,
         },
         poll,
     );

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -331,6 +331,7 @@ fn connect_<'a, 'b>(serv_addr: &str, pass: Option<&str>, poll: &'b Poll, tiny: &
             nicks: tiny.defaults.nicks.clone(),
             auto_cmds: tiny.defaults.auto_cmds.clone(),
             join: tiny.defaults.join.clone(),
+            auth: None,
         },
         poll,
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,13 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::path::Path;
 
+#[derive(Clone, Deserialize, Debug)]
+pub struct Auth {
+    pub sasl_method: String,
+    pub sasl_username: String,
+    pub sasl_password: String,
+}
+
 #[derive(Clone, Deserialize)]
 pub struct Server {
     /// Address of the server
@@ -43,6 +50,9 @@ pub struct Server {
     /// Channels to automatically join. Any `/join` commands in `auto_cmds` will be moved here.
     #[serde(default)]
     pub join: Vec<String>,
+
+    /// Authenication method
+    pub auth: Option<Auth>,
 }
 
 /// Similar to `Server`, but used when connecting via the `/connect` command.

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,14 +11,7 @@ use std::path::PathBuf;
 use std::path::Path;
 
 #[derive(Clone, Deserialize)]
-pub enum SASLMethod {
-    // Only PLAIN SASL is supported for now.
-    PLAIN
-}
-
-#[derive(Clone, Deserialize)]
-pub struct Auth {
-    pub sasl_method: SASLMethod,
+pub struct SASLAuth {
     pub sasl_username: String,
     pub sasl_password: String,
 }
@@ -58,7 +51,7 @@ pub struct Server {
     pub join: Vec<String>,
 
     /// Authenication method
-    pub auth: Option<Auth>,
+    pub sasl_auth: Option<SASLAuth>,
 }
 
 /// Similar to `Server`, but used when connecting via the `/connect` command.

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,15 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::path::Path;
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize)]
+pub enum SASLMethod {
+    // Only PLAIN SASL is supported for now.
+    PLAIN
+}
+
+#[derive(Clone, Deserialize)]
 pub struct Auth {
-    pub sasl_method: String,
+    pub sasl_method: SASLMethod,
     pub sasl_username: String,
     pub sasl_password: String,
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -509,7 +509,7 @@ impl<'poll> Conn<'poll> {
                 "NAK" => {
                     self.end_capability_negotiation();
                 }
-                &_ => {}
+                _ => {}
             };
         }
 
@@ -519,12 +519,14 @@ impl<'poll> Conn<'poll> {
         } = msg
         {
             if param.as_str() == "+" {
+                // Empty AUTHENTICATE response.  It means server accepted the specified SASL
+                // mechanism (PLAIN)
                 self.plain_sasl_authenticate();
             }
         }
 
         match msg.cmd {
-            // SASL authentication successful or failed
+            // 903: RPL_SASLSUCCESS, 904: ERR_SASLFAIL
             Cmd::Reply { num: 903, .. } | Cmd::Reply { num: 904, .. } => {
                 self.end_capability_negotiation();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,10 +736,20 @@ impl<'poll> Tiny<'poll> {
             Cmd::CAP { client: _, ref subcommand, ref params } => {
                 match subcommand.as_ref() {
                     "NAK" => {
-                        let msg_target = MsgTarget::Server {
-                            serv_name: conn.get_serv_name(),
-                        };
                         if params.iter().any(|cap| cap.as_str() == "sasl") {
+                            let msg_target = MsgTarget::Server {
+                                serv_name: conn.get_serv_name(),
+                            };
+                            self.tui.add_err_msg("Server rejected using SASL authenication capability",
+                                                 Timestamp::now(),
+                                                 &msg_target);
+                        }
+                    }
+                    "LS" => {
+                        if !params.iter().any(|cap| cap.as_str() == "sasl") {
+                            let msg_target = MsgTarget::Server {
+                                serv_name: conn.get_serv_name(),
+                            };
                             self.tui.add_err_msg("Server does not support SASL authenication",
                                                  Timestamp::now(),
                                                  &msg_target);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,12 @@ impl<'poll> Tiny<'poll> {
                                                  &msg_target);
                         }
                     }
-                    _ => {}
+                    "ACK" => {}
+                    cmd @ _ => {
+                        self.logger
+                            .get_debug_logs()
+                            .write_line(format_args!("CAP subcommand {} is not handled", cmd));
+                    }
                 };
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,6 +749,10 @@ impl<'poll> Tiny<'poll> {
                 };
             }
 
+            Cmd::AUTHENTICATE { .. } =>
+                // ignore
+                {}
+
             Cmd::Reply { num: n, params } => {
                 if n <= 003 /* RPL_WELCOME, RPL_YOURHOST, RPL_CREATED */
                         || n == 251 /* RPL_LUSERCLIENT */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,6 +733,22 @@ impl<'poll> Tiny<'poll> {
                 );
             }
 
+            Cmd::CAP { client: _, ref subcommand, ref params } => {
+                match subcommand.as_ref() {
+                    "NAK" => {
+                        let msg_target = MsgTarget::Server {
+                            serv_name: conn.get_serv_name(),
+                        };
+                        if params.iter().any(|cap| cap.as_str() == "sasl") {
+                            self.tui.add_err_msg("Server does not support SASL authenication",
+                                                 Timestamp::now(),
+                                                 &msg_target);
+                        }
+                    }
+                    &_ => {}
+                };
+            }
+
             Cmd::Reply { num: n, params } => {
                 if n <= 003 /* RPL_WELCOME, RPL_YOURHOST, RPL_CREATED */
                         || n == 251 /* RPL_LUSERCLIENT */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,7 @@ impl<'poll> Tiny<'poll> {
                                                  &msg_target);
                         }
                     }
-                    &_ => {}
+                    _ => {}
                 };
             }
 

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -156,6 +156,10 @@ pub enum Cmd {
         params: Vec<String>,
     },
 
+    AUTHENTICATE {
+        param: String,
+    },
+
     /// An IRC message other than the ones listed above.
     Other {
         cmd: String,
@@ -307,6 +311,10 @@ impl Msg {
                         client: params[0].to_owned(),
                         subcommand: params[1].to_owned(),
                         params: params[2].split(' ').map(|s| s.to_owned()).collect(),
+                    },
+                MsgType::Cmd("AUTHENTICATE") if params.len() == 1 =>
+                    Cmd::AUTHENTICATE {
+                        param: params[0].to_owned(),
                     },
                 MsgType::Num(n) =>
                     Cmd::Reply {

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -150,6 +150,12 @@ pub enum Cmd {
         topic: String,
     },
 
+    CAP {
+        client: String,
+        subcommand: String,
+        params: Vec<String>,
+    },
+
     /// An IRC message other than the ones listed above.
     Other {
         cmd: String,
@@ -295,6 +301,12 @@ impl Msg {
                     Cmd::TOPIC {
                         chan: params[0].to_owned(),
                         topic: params[1].to_owned(),
+                    },
+                MsgType::Cmd("CAP") if params.len() == 3 =>
+                    Cmd::CAP {
+                        client: params[0].to_owned(),
+                        subcommand: params[1].to_owned(),
+                        params: params[2].split(' ').map(|s| s.to_owned()).collect(),
                     },
                 MsgType::Num(n) =>
                     Cmd::Reply {

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -53,6 +53,18 @@ pub fn away<W: Write>(sink: &mut W, msg: Option<&str>) -> std::io::Result<()> {
     }
 }
 
+pub fn cap_req<W: Write>(sink: &mut W, cap_identifiers: &[&str]) -> std::io::Result<()> {
+    write!(sink, "CAP REQ :{}\r\n", cap_identifiers.join(" "))
+}
+
+pub fn cap_end<W: Write>(sink: &mut W) -> std::io::Result<()> {
+    write!(sink, "CAP END\r\n")
+}
+
+pub fn authenticate<W: Write>(sink: &mut W, msg: &str) -> std::io::Result<()> {
+    write!(sink, "AUTHENTICATE {}\r\n", msg)
+}
+
 /*
 pub fn quit<W : Write>(mut sink: W, msg : Option<&str>) -> std::io::Result<()> {
     match msg {

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -53,6 +53,10 @@ pub fn away<W: Write>(sink: &mut W, msg: Option<&str>) -> std::io::Result<()> {
     }
 }
 
+pub fn cap_ls<W: Write>(sink: &mut W) -> std::io::Result<()> {
+    write!(sink, "CAP LS\r\n")
+}
+
 pub fn cap_req<W: Write>(sink: &mut W, cap_identifiers: &[&str]) -> std::io::Result<()> {
     write!(sink, "CAP REQ :{}\r\n", cap_identifiers.join(" "))
 }


### PR DESCRIPTION
Need to set this in config file, as drafted in https://github.com/osa1/tiny/issues/30#issuecomment-342409032:
``` yaml
servers:                                                                                                                                              
    - addr: chat.freenode.net                                                                                                                         
      port: 6667                                                                                                                                      
      hostname: archlinux                                                                                                                             
      realname: Chiu Yue Chun                                                                                                                         
      nicks: [BrianOn99]                                                                                                                              
      auto_cmds: []                                                                                                                                   
      auth:                                                                                                                                           
          sasl_method: PLAIN                                                                                                                          
          sasl_username: BrianOn99                                                                                                                    
          sasl_password: password_hidden_for_security
```

Only PLAIN authenication is implemented.  I think it is sufficient for most users.

Fix #90 

I have only tested it on freenode.