### PR TITLE
Aur pkgbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ tiny is an IRC client written in Rust.
 Install the Rust nightly toolchain, clone the repo, and run `cargo install` (or
 `cargo install --force` if you already have an older version installed).
 
-Arch Linux users can use this
-[PKGBUILD](pkg/archlinux/PKGBUILD)
-to install tiny as a package. Download it into an empty directory, run
-`makepkg` and install the resulting .pkg.tar.xz with `sudo pacman -U`.
+Arch Linux users can install tiny from the
+[AUR](https://aur.archlinux.org/packages/tiny-irc-client-git/). Note
+that the supported way to meet the rust-nightly dependency is with the
+official
+[Rustup](https://www.archlinux.org/packages/community/x86_64/rustup/)
+package, but you can alternatively install Rustup via the [Rust
+Toolchain
+Installer](https://www.rust-lang.org/en-US/install.html). Either way, remember to
+install the Rust nightly toolchain before running makepkg.
 
 Since version 0.3.0 tiny needs OpenSSL or LibreSSL headers and runtime
 libraries. See [rust-openssl's

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -4,6 +4,7 @@ pkgver="0.4.0"
 pkgrel=1
 pkgdesc="A console IRC client"
 arch=('x86_64')
+provides=('tiny')
 url="https://github.com/osa1/tiny"
 license=('MIT')
 depends=('openssl' 'dbus')

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Nick Econopouly <wry@mm.st>
-pkgname=tiny-git
-pkgver="0.3.0"
+pkgname=tiny-irc-client-git
+pkgver="0.4.0"
 pkgrel=1
 pkgdesc="A console IRC client"
 arch=('x86_64')

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Nick Econopouly <wry@mm.st>
+# Maintainer: Nick Econopouly <wry at mm dot st>
 pkgname=tiny-irc-client-git
 pkgver="0.4.0"
 pkgrel=1

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="A console IRC client"
 arch=('x86_64')
 url="https://github.com/osa1/tiny"
 license=('MIT')
-depends=('openssl')
+depends=('openssl' 'dbus')
 makedepends=('git' 'rustup')
 
 build() {

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url="https://github.com/osa1/tiny"
 license=('MIT')
 depends=('openssl' 'dbus')
-makedepends=('git' 'rustup')
+makedepends=('git' 'rust-nightly')
 
 build() {
         return 0


### PR DESCRIPTION
This resolves #73. When binaries are available the AUR package will be called tiny-irc-client, as there's already a [tiny](https://aur.archlinux.org/packages/tiny).