### PR TITLE
Use relative paths of term_input and termbox_simple in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde_derive = "1.0.8"
 serde_yaml = "0.7.1"
 take_mut = "0.2.0"
 tempfile = "3.0.3"
-term_input = { path = "term_input" }
-termbox_simple = { path = "termbox" }
+term_input = { path = "term_input", version = "0.1.4" }
+termbox_simple = { path = "termbox", version = "0.2.2" }
 time = "0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde_derive = "1.0.8"
 serde_yaml = "0.7.1"
 take_mut = "0.2.0"
 tempfile = "3.0.3"
-term_input = "0.1.4"
-termbox_simple = "0.2.2"
+term_input = { path = "term_input" }
+termbox_simple = { path = "termbox" }
 time = "0.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(allocator_api)]
 #![feature(const_fn)]
 #![feature(drain_filter)]
-#![feature(entry_and_modify)]
 #![feature(nll)]
 #![feature(ptr_offset_from)]
 


### PR DESCRIPTION
This should fix CI. As far as I understand I should still be able to do
`cargo publish` as long as those packages are also published (or maybe
`cargo publish` publishes those for me if they're not? I'm not sure).