### PR TITLE
updated Arch Linux package and removed dated instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,7 @@ Install the Rust nightly toolchain, clone the repo, and run `cargo install` (or
 `cargo install --force` if you already have an older version installed).
 
 Arch Linux users can install tiny from the
-[AUR](https://aur.archlinux.org/packages/tiny-irc-client-git/). Note
-that the supported way to meet the rust-nightly dependency is with the
-official
-[Rustup](https://www.archlinux.org/packages/community/x86_64/rustup/)
-package, but you can alternatively install Rustup via the [Rust
-Toolchain
-Installer](https://www.rust-lang.org/en-US/install.html). Either way, remember to
-install the Rust nightly toolchain before running makepkg.
+[AUR](https://aur.archlinux.org/packages/tiny-irc-client-git/).
 
 Since version 0.3.0 tiny needs OpenSSL or LibreSSL headers and runtime
 libraries. See [rust-openssl's

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Nick Econopouly <wry at mm dot st>
 pkgname=tiny-irc-client-git
-pkgver="0.4.0"
+pkgver="0.4.3"
 pkgrel=1
 pkgdesc="A console IRC client"
 arch=('x86_64')
@@ -9,16 +9,27 @@ url="https://github.com/osa1/tiny"
 license=('MIT')
 depends=('openssl' 'dbus')
 makedepends=('git' 'rust-nightly')
+source=(git+$url)
+sha512sums=(SKIP)
 
 build() {
-        return 0
+           #  Installs the Rust nightly toolchain to a temporary
+           #  directory. If you already have the toolchain installed,
+           #  e.g. via the script at https://rustup.rs/ or another
+           #  package, you can remove the rust-nightly dependancy and
+           #  comment out the following three commands.
+          
+          mkdir nightly
+          export RUSTUP_HOME=$(pwd)/nightly
+          rustup toolchain install nightly
+
+          # build tiny
+          cd tiny
+          cargo +nightly build --release
 }
 
 package() {
-          git clone "$url.git"
           cd tiny
-          cargo +nightly build --release
           install -Dm755 target/release/tiny "$pkgdir/usr/bin/tiny"
           install -Dm644 LICENSE "$pkgdir/usr/share/licenses/tiny/LICENSE"
-
 }


### PR DESCRIPTION
from the README, the PKGBUILD now works out-of-the-box for all users but contains instructions for users with a preferred method of installing the Rust nightly toolchain. I updated the version on the AUR too.