### PR TITLE
Optimize Goto's

### DIFF
--- a/termbox/src/lib.rs
+++ b/termbox/src/lib.rs
@@ -410,16 +410,11 @@ fn num_to_buf(mut num: u16, buf: &mut Vec<u8>) {
         }
     }
 
-    if chars_len == 1 {
-        return;
-    }
-
     let swap_len = start_len + (chars_len / 2) as usize;
-    let mut cur_char;
     let mut c = 0;
     for i in start_len..swap_len {
         let next_swap_idx = start_len + chars_len - c - 1;
-        cur_char = buf[next_swap_idx];
+        let cur_char = buf[next_swap_idx];
         buf[next_swap_idx] = buf[i];
         buf[i] = cur_char;
         c += 1;

--- a/termbox/src/lib.rs
+++ b/termbox/src/lib.rs
@@ -387,23 +387,21 @@ impl Termbox {
     fn send_char(&mut self, to_x: u16, to_y: u16, ch: char) {
         // if the target cell is next to the last cell, then don't move the cursor
         if (self.last_cursor.0 + 1) == to_x && self.last_cursor.1 == to_y {
-            write!(self.output_buffer, "{}", ch).unwrap();
+            self.output_buffer.push(ch as u8);
         } else {
             goto(to_x, to_y, &mut self.output_buffer);
-            write!(self.output_buffer, "{}", ch).unwrap();
+            self.output_buffer.push(ch as u8);
         }
         self.last_cursor = (to_x, to_y);
     }
 }
-
-const LOOKUP: &[u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 fn num_to_buf(mut num: u16, buf: &mut Vec<u8>) {
     let start_len = buf.len();
     let mut chars_len = 0;
     loop {
         let rem = num % 10;
-        let ch = LOOKUP[rem as usize];
+        let ch = b'0' + rem as u8;
         buf.push(ch);
         num /= 10;
         chars_len += 1;
@@ -429,11 +427,11 @@ fn num_to_buf(mut num: u16, buf: &mut Vec<u8>) {
 }
 
 fn goto(x: u16, y: u16, buf: &mut Vec<u8>) {
-    write!(buf, "{}", "\x1B[").unwrap();
+    buf.extend_from_slice(b"\x1B[");
     num_to_buf(y, buf);
-    write!(buf, "{}", ';').unwrap();
+    buf.push(b';');
     num_to_buf(x, buf);
-    write!(buf, "{}", 'H').unwrap();
+    buf.push(b'H');
 }
 
 impl Drop for Termbox {

--- a/termbox/src/lib.rs
+++ b/termbox/src/lib.rs
@@ -385,13 +385,15 @@ impl Termbox {
     }
 
     fn send_char(&mut self, to_x: u16, to_y: u16, ch: char) {
-        // if the target cell is next to the last cell, then don't move the cursor
-        if (self.last_cursor.0 + 1) == to_x && self.last_cursor.1 == to_y {
-            self.output_buffer.push(ch as u8);
-        } else {
+        let mut ch_bytes = [0u8; 4];
+        let ch_str = ch.encode_utf8(&mut ch_bytes);
+
+        // if the target cell isn't next to the last cell, then move the cursor first
+        if self.last_cursor.0 + 1 != to_x || self.last_cursor.1 != to_y {
             goto(to_x, to_y, &mut self.output_buffer);
-            self.output_buffer.push(ch as u8);
         }
+        self.output_buffer.extend_from_slice(ch_str.as_bytes());
+
         self.last_cursor = (to_x, to_y);
     }
 }


### PR DESCRIPTION
This includes changes in the way Goto's are handled. First, it avoids
printing unnecesary Goto's. Second, it doesn't allocate when it needs to
print them.

This changes allow this termbox version to be as fast as the C version
of termbox.