### PR TITLE
Try both IPv4 and IPv6 addresses when domain resolves to both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- When an IRC server domain resolves to IPv4 and IPv6 addresses tiny now selects
+  one IPv4 and one IPv6 address and tries to connect to both. This works better
+  when a user can only connect to IPv4 or on to IPv6, but address name resolver
+  returns e.g. IPv6 address first when the user can only connect to IPv4 (#144).
+
 # 2019/10/05: 0.5.0
 
 Starting with this release tiny is no longer distributed on crates.io. Please


### PR DESCRIPTION
See #144 for the problem this solves. When a domain name resolves to IPv4 and IPv6 addresses we now try to connect to both, concurrently, and continue with the one that connects first. This solves the problem of user only being able to connect to IPv4 or IPv6 addresses.

An alternative would be to ask the user to choose whether to use IPv6 or not, and default to IPv4. I think this version is better; it doesn't require any input from the user (no need for a new tinyrc field) -- it just works.

Fixes #144