### PR TITLE
When a domain resolves to multiple addrs try all of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- When a domain name resolves to multiple IP addresses tiny now tries connecting
+  to the rest of the addresses when one fails (#144).
+
 # 2019/10/05: 0.5.0
 
 Starting with this release tiny is no longer distributed on crates.io. Please

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -26,9 +26,17 @@ pub(crate) async fn task(
 fn handle_conn_ev(ui: &dyn UI, client: &Client, ev: libtiny_client::Event) -> bool {
     use libtiny_client::Event::*;
     match ev {
-        Connecting => {
+        ResolvingHost => {
             ui.add_client_msg(
-                "Connecting...",
+                "Resolving host...",
+                &MsgTarget::AllServTabs {
+                    serv: client.get_serv_name(),
+                },
+            );
+        }
+        Connecting(sock_addr) => {
+            ui.add_client_msg(
+                &format!("Connecting to {}", sock_addr),
                 &MsgTarget::AllServTabs {
                     serv: client.get_serv_name(),
                 },
@@ -57,11 +65,7 @@ fn handle_conn_ev(ui: &dyn UI, client: &Client, ev: libtiny_client::Event) -> bo
         }
         IoErr(err) => {
             ui.add_err_msg(
-                &format!(
-                    "Connection error: {}. Will try to reconnect in {} seconds.",
-                    err.description(),
-                    libtiny_client::RECONNECT_SECS
-                ),
+                &format!("Connection error: {}", err.description()),
                 time::now(),
                 &MsgTarget::AllServTabs {
                     serv: client.get_serv_name(),
@@ -70,11 +74,7 @@ fn handle_conn_ev(ui: &dyn UI, client: &Client, ev: libtiny_client::Event) -> bo
         }
         TlsErr(err) => {
             ui.add_err_msg(
-                &format!(
-                    "TLS error: {}. Will try to reconnect in {} seconds.",
-                    err.description(),
-                    libtiny_client::RECONNECT_SECS
-                ),
+                &format!("TLS error: {}", err.description()),
                 time::now(),
                 &MsgTarget::AllServTabs {
                     serv: client.get_serv_name(),


### PR DESCRIPTION
Previously we'd just try the first address, failing that we'd just wait 30 seconds and try again. This caused problems when a user can only connect to some of the addresses (e.g. they can't connect to IPv6 but can connect to IPv4, but the first address returned is IPv6).

Fixes #144