### PR TITLE
Add a toolchain override file pointing to nightly

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Resolves #155 

Hey! This seems to work for me. If I set my default toolchain to `stable`, then I `cd` into the repo directory, `rustup show` yields this:
```
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/ebroto/.rustup

installed toolchains
--------------------

stable-x86_64-unknown-linux-gnu (default)
beta-x86_64-unknown-linux-gnu
nightly-2019-08-22-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu

active toolchain
----------------

nightly-x86_64-unknown-linux-gnu (overridden by '/home/ebroto/src/ebroto-tiny/rust-toolchain')
rustc 1.40.0-nightly (7979016af 2019-10-20)
``` 

Then building with `-vv`:
```
Compiling tiny v0.5.0 (/home/ebroto/src/ebroto-tiny)
     Running `CARGO_PKG_VERSION_MINOR=5 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_NAME=tiny CARGO_PKG_DESCRIPTION='An IRC client' LD_LIBRARY_PATH='/home/ebroto/src/ebroto-tiny/target/debug/deps:/home/ebroto/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib:/home/ebroto/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib' CARGO_PKG_REPOSITORY='https://github.com/osa1/tiny' CARGO_PKG_VERSION_PRE= CARGO_PKG_AUTHORS='Ömer Sinan Ağacan <omeragacan@gmail.com>' CARGO_PKG_VERSION_PATCH=0 CARGO_PKG_VERSION=0.5.0 CARGO_PKG_HOMEPAGE= CARGO=/home/ebroto/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo CARGO_MANIFEST_DIR=/home/ebroto/src/ebroto-tiny rustc --edition=2018 --crate-name tiny src/main.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=3d51417be9d2dd3e -C extra-filename=-3d51417be9d2dd3e --out-dir /home/ebroto/src/ebroto-tiny/target/debug/deps -C incremental=/home/ebroto/src/ebroto-tiny/target/debug/incremental -L dependency=/home/ebroto/src/ebroto-tiny/target/debug/deps --extern dirs=/home/ebroto/src/ebroto-tiny/target/debug/deps/libdirs-1529c5fa535e63e4.rlib --extern env_logger=/home/ebroto/src/ebroto-tiny/target/debug/deps/libenv_logger-f8004733baac4f56.rlib --extern futures_util=/home/ebroto/src/ebroto-tiny/target/debug/deps/libfutures_util-42ad6c3b7a6a7603.rlib --extern libtiny_client=/home/ebroto/src/ebroto-tiny/target/debug/deps/liblibtiny_client-61978c7b0709a3f5.rlib --extern libtiny_logger=/home/ebroto/src/ebroto-tiny/target/debug/deps/liblibtiny_logger-0399060f775386a0.rlib --extern libtiny_tui=/home/ebroto/src/ebroto-tiny/target/debug/deps/liblibtiny_tui-a80d3f21c83a8925.rlib --extern libtiny_ui=/home/ebroto/src/ebroto-tiny/target/debug/deps/liblibtiny_ui-8f1973988bbb929a.rlib --extern libtiny_wire=/home/ebroto/src/ebroto-tiny/target/debug/deps/liblibtiny_wire-f7b4b35cb650c691.rlib --extern log=/home/ebroto/src/ebroto-tiny/target/debug/deps/liblog-62408d43c7b84b61.rlib --extern serde=/home/ebroto/src/ebroto-tiny/target/debug/deps/libserde-d6fdac9fd2c869d9.rlib --extern serde_yaml=/home/ebroto/src/ebroto-tiny/target/debug/deps/libserde_yaml-9c7cdf54c204d111.rlib --extern time=/home/ebroto/src/ebroto-tiny/target/debug/deps/libtime-6f33dfbb1210b4c5.rlib --extern tokio=/home/ebroto/src/ebroto-tiny/target/debug/deps/libtokio-5f7b37de118f4833.rlib -L native=/usr/lib/x86_64-linux-gnu`
    Finished dev [unoptimized + debuginfo] target(s) in 48.17s
```

Are you sure you don't have something set with more precedence, like the env var `RUSTUP_TOOLCHAIN`?