### PR TITLE
Implement user configurable timestamp formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   location. The old location `$HOME/.tinyrc.yml` is still used when there isn't
   a config file in the new location, to avoid breakage. `$HOME/.config` is used
   for `$XDG_CONFIG_HOME` when the env variable is not available (#152).
+- Timestamps can now be configured using the new (optional) `timestamp_format`
+  field in the config. Value should be a valid `strftime()` format string (see
+  `man strftime` for details). Default value is the same as before (`%H:%M`).
+  (#161)
 
 # 2019/10/05: 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ tiny is an IRC client written in Rust.
 
 - Configurable colors
 
+- Configurable timestamps
+
 - SASL authentication
 
 - Configurable desktop notifications on new messages
@@ -169,7 +171,7 @@ Commands start with `/` character.
 - `/names`: List all nicks in the current channel. You can use `/names <nick>` to
   check if a specific nick is in the channel.
 
-- `/reload`: Reload configuration
+- `/reload`: Reload TUI colors from the config file
 
 - `/clear`: Clears tab contents
 

--- a/libtiny_tui/examples/bench.rs
+++ b/libtiny_tui/examples/bench.rs
@@ -9,7 +9,6 @@ use libtiny_tui::TUI;
 use libtiny_ui::*;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
 use tokio::runtime::current_thread::Runtime;
 
 fn main() {
@@ -20,13 +19,11 @@ fn main() {
     let lines = file_buffered.lines().map(Result::unwrap).collect();
 
     let mut executor = Runtime::new().unwrap();
-    let (tui, _) = TUI::run(PathBuf::from("../tiny/config.yml"), &mut executor);
+    let (tui, _) = TUI::run(None, &mut executor);
 
     tui.draw();
 
     executor.block_on(bench_task(tui, lines));
-
-    // executor.run();
 }
 
 async fn bench_task(tui: TUI, lines: Vec<String>) {

--- a/libtiny_tui/src/config.rs
+++ b/libtiny_tui/src/config.rs
@@ -4,6 +4,7 @@
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::Deserialize;
 use serde_yaml;
+use std::default::Default;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -14,6 +15,23 @@ pub use termbox_simple::*;
 pub(crate) struct Config {
     #[serde(default)]
     pub(crate) colors: Colors,
+
+    /// A valid `strftime()` format string used when showing timestamps. Validated in `TUI::new`.
+    #[serde(default = "def_ts_fmt")]
+    pub(crate) timestamp_format: String,
+}
+
+pub(crate) fn def_ts_fmt() -> String {
+    "%H:%M".to_string()
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            colors: Colors::default(),
+            timestamp_format: def_ts_fmt(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libtiny_tui/src/lib.rs
+++ b/libtiny_tui/src/lib.rs
@@ -41,7 +41,10 @@ pub struct TUI {
 }
 
 impl TUI {
-    pub fn run(config_path: PathBuf, runtime: &mut Runtime) -> (TUI, mpsc::Receiver<Event>) {
+    pub fn run(
+        config_path: Option<PathBuf>,
+        runtime: &mut Runtime,
+    ) -> (TUI, mpsc::Receiver<Event>) {
         let tui = Rc::new(RefCell::new(tui::TUI::new(config_path)));
         let inner = Rc::downgrade(&tui);
 

--- a/libtiny_tui/src/msg_area/line.rs
+++ b/libtiny_tui/src/msg_area/line.rs
@@ -60,7 +60,7 @@ pub(crate) enum SchemeStyle {
 }
 
 impl Seg {
-    pub(crate) fn style(&self, colors: &Colors) -> config::Style {
+    fn style(&self, colors: &Colors) -> config::Style {
         match self.style {
             SegStyle::Fixed(style) => style,
             SegStyle::Index(idx) => config::Style {
@@ -106,15 +106,15 @@ impl Line {
         if self.current_seg.text.is_empty() {
             self.current_seg.style = style;
         } else if self.current_seg.style != style {
-            let seg = mem::replace(
-                &mut self.current_seg,
-                Seg {
-                    text: String::new(),
-                    style,
-                },
-            );
-            self.segs.push(seg);
+            self.flush_current_seg(style);
         }
+    }
+
+    pub(crate) fn add_timestamp(&mut self, ts_str: &str) {
+        debug_assert!(self.segs.is_empty());
+        self.set_style(SegStyle::SchemeStyle(SchemeStyle::Timestamp));
+        self.add_text(ts_str);
+        self.add_char(' ');
     }
 
     pub(crate) fn add_text(&mut self, str: &str) {
@@ -262,6 +262,17 @@ impl Line {
                 char_idx += 1;
             }
         }
+    }
+
+    fn flush_current_seg(&mut self, style: SegStyle) {
+        let seg = mem::replace(
+            &mut self.current_seg,
+            Seg {
+                text: String::new(),
+                style,
+            },
+        );
+        self.segs.push(seg);
     }
 }
 

--- a/libtiny_tui/src/msg_area/mod.rs
+++ b/libtiny_tui/src/msg_area/mod.rs
@@ -143,6 +143,10 @@ impl MsgArea {
         self.line_buf.set_style(style);
     }
 
+    pub(crate) fn add_timestamp(&mut self, ts_str: &str) {
+        self.line_buf.add_timestamp(ts_str);
+    }
+
     pub(crate) fn add_text(&mut self, str: &str) {
         self.line_buf.add_text(str);
     }

--- a/tiny/config.yml
+++ b/tiny/config.yml
@@ -37,6 +37,10 @@ defaults:
 # Where to put log files
 log_dir: '{}'
 
+# How to show timestamps. Should be a valid strftime() format string. Run `man
+# strftime` in your shell for strftime format specification.
+timestamp_format: '%H:%M'
+
 # Color theme based on 256 colors. Colors can be defined as color indices
 # (0-255) or with their names.
 #

--- a/tiny/src/main.rs
+++ b/tiny/src/main.rs
@@ -78,7 +78,7 @@ fn run(
     let mut executor = tokio::runtime::current_thread::Runtime::new().unwrap();
 
     // Create TUI task
-    let (tui, rcv_tui_ev) = TUI::run(config_path.clone(), &mut executor);
+    let (tui, rcv_tui_ev) = TUI::run(Some(config_path.clone()), &mut executor);
     tui.draw();
 
     // Create logger


### PR DESCRIPTION
Did this during a 11h flight today ..

Here's a screenshot of how this looks when I add `timestamp_format: '%A %H:%M:%S'` to my config file:

![Screenshot_2019-12-24_07-46-25](https://user-images.githubusercontent.com/448274/71394196-837cec80-2621-11ea-815e-668124414be9.png)

This also re-enables the `/reload` command and makes a few other unrelated changes. I'll move those commit to the master branch and rebase this.

The code is not final, it has some bugs. I observed a crash while tweaking the format string and doing `/reload`. There also seems to be issues with splitting lines.

Fixes #159