### PR TITLE
A framework for TUI tests

### DIFF
--- a/libtiny_tui/src/lib.rs
+++ b/libtiny_tui/src/lib.rs
@@ -18,6 +18,9 @@ mod tui;
 mod utils;
 mod widget;
 
+#[cfg(test)]
+mod tests;
+
 pub use crate::tab::TabStyle;
 pub use libtiny_ui::*;
 

--- a/libtiny_tui/src/tests/mod.rs
+++ b/libtiny_tui/src/tests/mod.rs
@@ -1,0 +1,107 @@
+use crate::tui::TUI;
+
+use termbox_simple::CellBuf;
+
+fn buffer_str(buf: &CellBuf, w: u16, h: u16) -> String {
+    let w = usize::from(w);
+    let h = usize::from(h);
+
+    let mut ret = String::with_capacity(w * h);
+
+    for y in 0..h {
+        for x in 0..w {
+            let ch = buf.cells[(y * usize::from(w)) + x].ch;
+            ret.push(ch);
+        }
+        if y != h - 1 {
+            ret.push('\n');
+        }
+    }
+
+    ret
+}
+
+fn expect_screen(screen: &str, tui: &TUI, w: u16, h: u16) {
+    let mut screen_filtered = String::with_capacity(screen.len());
+
+    let mut in_screen = false;
+    for c in screen.chars() {
+        if in_screen {
+            if c == '|' {
+                screen_filtered.push('\n');
+                in_screen = false;
+            } else {
+                screen_filtered.push(c);
+            }
+        } else if c == '|' {
+            in_screen = true;
+        }
+    }
+    let _ = screen_filtered.pop(); // pop the last '\n'
+
+    let found = buffer_str(&tui.get_tb().get_front_buffer(), w, h);
+    if screen_filtered != found {
+        panic!(
+            "Unexpected screen\nExpected:\n{:?}\nFound:\n{:?}",
+            screen_filtered, found
+        );
+    }
+}
+
+#[test]
+fn init_screen() {
+    let mut tui = TUI::new_test(20, 4);
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|Any mentions to you |
+         |will be listed here.|
+         |                    |
+         |mentions            |";
+    expect_screen(screen, &tui, 20, 4);
+}
+
+#[test]
+fn close_rightmost_tab() {
+    // After closing right-most tab the tab bar should scroll left.
+    let mut tui = TUI::new_test(20, 4);
+    tui.new_server_tab("irc.server_1.org");
+    tui.new_server_tab("irc.server_2.org");
+    tui.next_tab();
+    tui.next_tab();
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|                    |
+         |                    |
+         |                    |
+         |< irc.server_2.org  |";
+    expect_screen(screen, &tui, 20, 4);
+
+    // Should scroll left when the server tab is closed. Left arrow should still be visible as
+    // there are still tabs to the left.
+    tui.close_server_tab("irc.server_2.org");
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|                    |
+         |                    |
+         |                    |
+         |< irc.server_1.org  |";
+    expect_screen(screen, &tui, 20, 4);
+
+    // Scroll left again, left arrow should disappear this time.
+    tui.close_server_tab("irc.server_1.org");
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|Any mentions to you |
+         |will be listed here.|
+         |                    |
+         |mentions            |";
+    expect_screen(screen, &tui, 20, 4);
+}


### PR DESCRIPTION
This PR adds a way to test TUI rendering without actually doing any rendering to the terminal. An example test shows how to define a test:

```rust
#[test]
fn init_screen() {
    let mut tui = TUI::new_test(20, 10);
    tui.draw();

    #[rustfmt::skip]
    let screen =
        "|                    |
         |                    |
         |                    |
         |                    |
         |                    |
         |                    |
         |Any mentions to you |
         |will be listed here.|
         |                    |
         |mentions            |";

    expect_screen(screen, &tui);
}
```

This creates a new test instance of the TUI, draws it (not to the terminal, only to termbox's internal buffer), and then compares the screen with the given screen. The screen bounds are marked with `|`s.

There are pretty much no runtime overheads of this addition. Only changes in termbox is that it now works without a tty (some conditionals in a few places check if have a tty when drawing). When tty doesn't exist we only update the internal buffer. A new method `Termbox::get_front_buffer_str` returns a copy of the internal buffer as a `String`. We then compare that string with the provided specification in the tests. Simple enough!

One caveat is that we currently don't support color and style specifiers when generating the buffer string in `get_front_buffer_str`. That shouldn't be too hard to implement, I'm just not sure how to encode those in a `String`. One alternative would be to return a copy of the buffer itself, instead of encoding it in a string. That way the test framework would be free to check in different ways.