### PR TITLE
Make desktop notifications feature (dbus) optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install native dependencies
-        run: sudo apt-get install libdbus-1-dev pkg-config libssl-dev
-
       - name: Get nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -28,14 +25,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-  Linux_rustls:
-    name: '[Linux, rustls] Build'
+  Linux_native_tls_notif:
+    name: '[Linux, native TLS + notifications] Build'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Install native dependencies
-        run: sudo apt-get install libdbus-1-dev
+        run: sudo apt-get install libdbus-1-dev pkg-config libssl-dev
 
       - name: Get nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -44,10 +41,13 @@ jobs:
             components: rustfmt
             override: true
 
-      - name: Build with rustls
-        run: cd tiny && cargo build --verbose --no-default-features --features tls-rustls
+      - name: Build with rustls and dbus
+        run: |
+          cd tiny
+          cargo build --verbose --no-default-features \
+            --features "tls-native desktop-notifications"
 
-  OSX:
+  OSX_default:
     name: '[OSX, default] Build and test'
     runs-on: macos-latest
     steps:
@@ -66,11 +66,8 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-  OSX_rustls:
-    name: '[OSX, rustls] Build'
+  OSX_native_tls_notif:
+    name: '[OSX, native TLS + notifications] Build'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -83,4 +80,7 @@ jobs:
             override: true
 
       - name: Build
-        run: cd tiny && cargo build --verbose --no-default-features --features tls-rustls
+        run: |
+          cd tiny
+          cargo build --verbose --no-default-features \
+            --features "tls-native desktop-notifications"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,58 @@ jobs:
             components: rustfmt
             override: true
 
-      - name: Make release tarball (libssl + libdbus)
+      - name: Make release tarball (default)
         run: |
           (cd tiny && cargo build --release --verbose)
+          tar -C target/release -czvf tiny-ubuntu-18.04.tar.gz tiny
+
+      - name: Make release tarball (default, statically linked)
+        run: |
+          (cd tiny && cargo build --release --verbose --target=x86_64-unknown-linux-musl)
+          tar -C target/x86_64-unknown-linux-musl/release \
+            -czvf tiny-ubuntu-18.04-static.tar.gz tiny
+
+      - name: Make release tarball (libssl)
+        run: |
+          (cd tiny && cargo build --release --verbose \
+            --no-default-features --features="tls-native")
           tar -C target/release -czvf tiny-ubuntu-18.04-libssl.tar.gz tiny
 
-      - name: Make release tarball (rustls + libdbus)
+      - name: Make release tarball (libdbus)
         run: |
-          (cd tiny && cargo build --release --verbose --no-default-features --features tls-rustls)
-          tar -C target/release -czvf tiny-ubuntu-18.04-rustls.tar.gz tiny
+          (cd tiny && cargo build --release --verbose \
+            --no-default-features --features="desktop-notifications")
+          tar -C target/release -czvf tiny-ubuntu-18.04-dbus.tar.gz tiny
+
+      - name: Make release tarball (libssl + libdbus)
+        run: |
+          (cd tiny && cargo build --release --verbose \
+            --no-default-features --features="tls-native desktop-notifications")
+          tar -C target/release -czvf tiny-ubuntu-18.04-libssl-dbus.tar.gz tiny
 
       # TODO: Can I not do this in one step?
 
-      - name: Upload executable (1/2)
+      - name: Upload executable (1/5)
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: tiny-ubuntu-18.04.tar.gz
+          asset_name: tiny-ubuntu-18.04.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload executable (2/5)
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: tiny-ubuntu-18.04-static.tar.gz
+          asset_name: tiny-ubuntu-18.04-static.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload executable (3/5)
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -56,12 +95,22 @@ jobs:
           asset_name: tiny-ubuntu-18.04-libssl.tar.gz
           asset_content_type: application/gzip
 
-      - name: Upload executable (2/2)
+      - name: Upload executable (4/5)
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tiny-ubuntu-18.04-rustls.tar.gz
-          asset_name: tiny-ubuntu-18.04-rustls.tar.gz
+          asset_path: tiny-ubuntu-18.04-dbus.tar.gz
+          asset_name: tiny-ubuntu-18.04-dbus.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload executable (4/5)
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: tiny-ubuntu-18.04-libssl-dbus.tar.gz
+          asset_name: tiny-ubuntu-18.04-libssl-dbus.tar.gz
           asset_content_type: application/gzip

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ tiny is an IRC client written in Rust.
 
 - SASL authentication
 
-- Configurable desktop notifications on new messages
+- Configurable desktop notifications on new messages (opt-in feature behind a
+  feature flag, see below)
 
 - znc compatible
 
@@ -47,7 +48,21 @@ tiny is an IRC client written in Rust.
 
 ## Installation
 
-Install the Rust nightly toolchain, clone the repo, and run
+For pre-build binaries see [releases]. To build from source install Rust nightly
+toolchain. By default tiny uses [rustls] for TLS support, and desktop
+notifications are disabled.
+
+[releases]: https://github.com/osa1/tiny/releases
+[rustls]: https://github.com/ctz/rustls
+
+- To use system TLS library (OpenSSL or LibreSSL), add `--no-default-features
+  --features=tls-native` to the command you're using. Note that this requires
+  OpenSSL or LibreSSL headers and runtime libraries on Linux.
+
+- To enable desktop notifications add `--features=desktop-notifications`. This
+  requires libdbus on Linux.
+
+To install in a clone:
 
 ```
 cargo install --path tiny
@@ -62,29 +77,9 @@ cargo install --git https://github.com/osa1/tiny
 If you have an older version installed, add `--force` to the command you're
 using.
 
-Arch Linux users can install tiny from the [AUR].
+Arch Linux users can install tiny from [AUR].
 
 [AUR]: https://aur.archlinux.org/packages/tiny-irc-client-git/
-
-Since version 0.3.0 tiny needs OpenSSL or LibreSSL headers and runtime
-libraries. See [rust-openssl documentation] for installation instructions.
-
-[rust-openssl documentation]: https://docs.rs/openssl/0.10.26/openssl/#automatic
-
-### Using rustls instead of native TLS library
-
-To use [rustls], add `--no-default-features --features tls-rustls` to the
-install command you're using.
-
-When building with rustls tiny doesn't require a native SSL library (OpenSSL or
-LibreSSL).
-
-[rustls]: https://github.com/ctz/rustls
-
-### Dependencies
-
-* OpenSSL or LibreSSL (default, not when rustls is used)
-* libdbus (Linux only)
 
 tiny is tested on Linux and OSX.
 

--- a/libtiny_client/Cargo.toml
+++ b/libtiny_client/Cargo.toml
@@ -6,7 +6,7 @@ description = "An IRC client library, mainly to be used in tiny"
 edition = "2018"
 
 [features]
-default = ["tls-native"]
+default = ["tls-rustls"]
 tls-native = ["native-tls", "tokio-tls"]
 tls-rustls = ["rustls-native-certs", "tokio-rustls"]
 

--- a/libtiny_tui/Cargo.toml
+++ b/libtiny_tui/Cargo.toml
@@ -4,12 +4,16 @@ version = "0.1.0"
 description = "A terminal UI for tiny"
 edition = "2018"
 
+[features]
+default = []
+desktop-notifications = ["notify-rust"]
+
 [dependencies]
 env_logger = "0.7"
 futures = "0.3.1"
 libtiny_ui = { path = "../libtiny_ui" }
 log = "0.4"
-notify-rust = "3"
+notify-rust = { version = "3", optional = true }
 serde = { version = "1.0.8", features = ["derive"] }
 serde_yaml = "0.7.1"
 tempfile = "3.0.3"

--- a/libtiny_tui/src/notifier.rs
+++ b/libtiny_tui/src/notifier.rs
@@ -1,4 +1,6 @@
 use crate::{utils::remove_irc_control_chars, MsgTarget};
+
+#[cfg(feature = "desktop-notifications")]
 use notify_rust::Notification;
 
 /// Destktop notification handler
@@ -12,10 +14,14 @@ pub(crate) enum Notifier {
     Messages,
 }
 
+#[cfg(feature = "desktop-notifications")]
 fn notify(summary: &str, body: &str) {
     // TODO: Report errors somehow
     let _ = Notification::new().summary(summary).body(body).show();
 }
+
+#[cfg(not(feature = "desktop-notifications"))]
+fn notify(_summary: &str, _body: &str) {}
 
 impl Notifier {
     pub(crate) fn notify_privmsg(

--- a/tiny/Cargo.toml
+++ b/tiny/Cargo.toml
@@ -9,9 +9,10 @@ description = "An IRC client"
 edition = "2018"
 
 [features]
-default = ["tls-native"]
+default = ["tls-rustls"]
 tls-native = ["libtiny_client/tls-native"]
 tls-rustls = ["libtiny_client/tls-rustls"]
+desktop-notifications = ["libtiny_tui/desktop-notifications"]
 
 [dependencies]
 dirs = "1.0.2"
@@ -19,7 +20,7 @@ env_logger = "0.7"
 futures = "0.3.1"
 libtiny_client = { path = "../libtiny_client", default-features = false }
 libtiny_logger = { path = "../libtiny_logger" }
-libtiny_tui = { path = "../libtiny_tui" }
+libtiny_tui = { path = "../libtiny_tui", default-features = false }
 libtiny_ui = { path = "../libtiny_ui" }
 libtiny_wire = { path = "../libtiny_wire" }
 log = "0.4"


### PR DESCRIPTION
With this I can make a statically linked executable with

    $ cargo build --target=x86_64-unknown-linux-musl \
        --no-default-features --features tls-rustls

The generated executable does not support generating desktop
notifications and uses rustls instead of libssl.

(#65)