### PR TITLE
Fix a text field bug when updating scroll after C-w

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
   of on every new connection. (#172)
 - It's now possible to build tiny with [rustls] instead of [native-tls]. See
   README for instructions. (#172)
-- A bug when rendering exit dialogue (shown on C-c) fixed.
+- A bug when rendering exit dialogue (shown on `C-c`) fixed.
 - A new optional server field 'alias' added to the configuration file for
   specifying aliases for servers, to be shown in the tab line. This is useful
   when a server address is long, or just an IP address, or you want to show
   something different than the server address in the tab bar (#186).
+- TUI: A text field bug is fixed when updating the scroll value after deleting a
+  word with `C-w`.
 
 [rustls]: https://github.com/ctz/rustls
 [native-tls]: https://github.com/sfackler/rust-native-tls

--- a/libtiny_tui/src/lib.rs
+++ b/libtiny_tui/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(test, feature(test))]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::cognitive_complexity)]
+#![feature(track_caller)]
 
 mod config;
 mod exit_dialogue;


### PR DESCRIPTION
Previous buggy behavior shown in the new test.

Other changes:

- expect_screen error reporting improved for easier comparison of expected and seen screens
- expect_screen now takes a caller location for better error reporting