### PR TITLE
term_input: A more efficient key combination parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tempfile",
- "term_input 0.1.5",
+ "term_input 0.2.0",
  "termbox_simple",
  "time",
  "tokio",
@@ -1207,16 +1207,6 @@ dependencies = [
 [[package]]
 name = "term_input"
 version = "0.1.5"
-dependencies = [
- "futures",
- "libc",
- "mio",
- "tokio",
-]
-
-[[package]]
-name = "term_input"
-version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad2df816a0a43d0075d4c888328d31c888ba1e418e25a4638f27eac170ac824"
 dependencies = [
@@ -1225,12 +1215,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_input"
+version = "0.2.0"
+dependencies = [
+ "futures",
+ "libc",
+ "mio",
+ "term_input_macros",
+ "tokio",
+]
+
+[[package]]
+name = "term_input_macros"
+version = "0.2.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "termbox_simple"
 version = "0.2.3"
 dependencies = [
  "libc",
  "mio",
- "term_input 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_input 0.1.5",
  "termion",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "libtiny_ui",
     "libtiny_wire",
     "term_input",
+    "term_input_macros",
     "termbox",
     "tiny",
 ]

--- a/term_input/Cargo.toml
+++ b/term_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "term_input"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Ömer Sinan Ağacan <omeragacan@gmail.com>"]
 description = "Input handling for xterm-compatible terminals"
 repository = "https://github.com/osa1/tiny"
@@ -11,4 +11,5 @@ edition = "2018"
 futures = "0.3.1"
 libc = "0.2"
 mio = "0.6"
+term_input_macros = { path = "../term_input_macros" }
 tokio = { version = "0.2.11", features = ["full"] }

--- a/term_input_macros/Cargo.toml
+++ b/term_input_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "term_input_macros"
+version = "0.2.0"
+authors = ["Ömer Sinan Ağacan <omeragacan@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/term_input_macros/src/lib.rs
+++ b/term_input_macros/src/lib.rs
@@ -1,0 +1,23 @@
+mod syntax;
+mod tree;
+
+use syntax::Input;
+
+use proc_macro::TokenStream;
+use quote::quote;
+
+#[proc_macro]
+pub fn byte_seq_parser(input: TokenStream) -> TokenStream {
+    let Input {
+        fn_name,
+        fn_return_type,
+        rules,
+    } = syn::parse_macro_input!(input as syntax::Input);
+    let fn_body = tree::build_decision_tree(rules);
+
+    quote!(fn #fn_name(buf: &[u8]) -> Option<(#fn_return_type, usize)> {
+        let mut i: usize = 0;
+        #fn_body
+    })
+    .into()
+}

--- a/term_input_macros/src/syntax.rs
+++ b/term_input_macros/src/syntax.rs
@@ -1,0 +1,109 @@
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+
+#[derive(Debug)]
+pub(crate) struct Pattern(pub(crate) Vec<u8>);
+
+#[derive(Debug)]
+pub(crate) struct Value(pub(crate) syn::Expr);
+
+#[derive(Debug)]
+pub(crate) struct Rule {
+    pub(crate) pattern: Pattern,
+    pub(crate) value: Value,
+}
+
+#[derive(Debug)]
+pub(crate) struct Input {
+    pub(crate) fn_name: syn::Ident,
+    pub(crate) fn_return_type: syn::Type,
+    pub(crate) rules: Vec<Rule>,
+}
+
+fn parse_byte_array_elems(array: syn::ExprArray) -> syn::Result<Vec<u8>> {
+    let mut ret = Vec::with_capacity(array.elems.len());
+
+    if array.elems.is_empty() {
+        return Err(syn::Error::new(array.span(), "blah"));
+    }
+
+    for pair in array.elems.into_pairs() {
+        let lit = match pair.into_value() {
+            syn::Expr::Lit(lit) => lit,
+            other => {
+                return Err(syn::Error::new(other.span(), "blah"));
+            }
+        };
+
+        match lit.lit {
+            syn::Lit::Byte(byte) => ret.push(byte.value()),
+            syn::Lit::Int(int) => {
+                let val = int.base10_parse::<u8>()?;
+                ret.push(val);
+            }
+            other => {
+                return Err(syn::Error::new(other.span(), "blah"));
+            }
+        }
+    }
+
+    Ok(ret)
+}
+
+fn parse_byte_string(str: syn::LitByteStr) -> syn::Result<Vec<u8>> {
+    if str.value().is_empty() {
+        return Err(syn::Error::new(str.span(), "blah"));
+    }
+
+    Ok(str.value())
+}
+
+impl Parse for Pattern {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        // Either a u8 array with just literals, or a byte string
+        let string = input.parse::<syn::LitByteStr>();
+        let array = input.parse::<syn::ExprArray>();
+
+        match array {
+            Ok(array) => Ok(Pattern(parse_byte_array_elems(array)?)),
+            Err(_) => match string {
+                Err(_) => Err(syn::Error::new(input.span(), "blah")),
+                Ok(str) => Ok(Pattern(parse_byte_string(str)?)),
+            },
+        }
+    }
+}
+
+impl Parse for Value {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Value(input.parse()?))
+    }
+}
+
+impl Parse for Rule {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let pattern = input.parse()?;
+        input.parse::<syn::Token![=>]>()?;
+        let value = input.parse()?;
+        Ok(Rule { pattern, value })
+    }
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let fn_name = input.parse::<syn::Ident>()?;
+        input.parse::<syn::Token![->]>()?;
+        let fn_return_type = input.parse::<syn::Type>()?;
+
+        input.parse::<syn::Token![,]>()?;
+        let rules = syn::punctuated::Punctuated::<Rule, syn::Token![,]>::parse_terminated(input)?
+            .into_pairs()
+            .map(|pair| pair.into_value())
+            .collect();
+        Ok(Input {
+            fn_name,
+            fn_return_type,
+            rules,
+        })
+    }
+}

--- a/term_input_macros/src/tree.rs
+++ b/term_input_macros/src/tree.rs
@@ -1,0 +1,113 @@
+use crate::syntax::*;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use quote::TokenStreamExt;
+use std::collections::HashMap;
+use syn;
+
+struct Node {
+    value: Option<syn::Expr>,
+    next: HashMap<u8, Node>,
+}
+
+impl Node {
+    fn new() -> Self {
+        Node {
+            value: None,
+            next: HashMap::new(),
+        }
+    }
+
+    fn to_token_stream(&self) -> TokenStream {
+        let Node { value, next } = self;
+
+        let node_value = match value {
+            None => quote!(None),
+            Some(expr) => quote!(Some((#expr, i))),
+        };
+
+        // Optimize the case when the node is a leaf. Not necessary for correctness, but makes the
+        // generated code smaller.
+        if next.is_empty() {
+            return quote!(#node_value).into();
+        }
+
+        let mut match_arms = vec![];
+        for (byte, next) in next.iter() {
+            let next_tokens = next.to_token_stream();
+            match_arms.push(quote!(
+                #byte => {
+                    i += 1;
+                    #next_tokens
+                }
+            ));
+        }
+        match_arms.push(quote!(_ => #node_value));
+
+        quote!(
+            match buf.get(i) {
+                None => #node_value,
+                Some(byte) => {
+                    match byte {
+                        #(#match_arms,)*
+                    }
+                }
+            }
+        )
+        .into()
+    }
+
+    fn add_rule(&mut self, rule: Rule) {
+        let Rule { pattern, value } = rule;
+        let pattern: Vec<u8> = pattern.0;
+        let value: syn::Expr = value.0;
+
+        let byte = pattern[0];
+        let rest = &pattern[1..];
+
+        match self.next.get_mut(&byte) {
+            None => {
+                let mut node = Node::new();
+                node.add_rule_(rest, value);
+                self.next.insert(byte, node);
+            }
+            Some(node) => {
+                node.add_rule_(rest, value);
+            }
+        }
+    }
+
+    fn add_rule_(&mut self, bytes: &[u8], value: syn::Expr) {
+        if bytes.is_empty() {
+            assert!(self.value.is_none()); // TODO: improve the err msg
+            self.value = Some(value);
+        } else {
+            let byte = bytes[0];
+            let rest = &bytes[1..];
+
+            match self.next.get_mut(&byte) {
+                None => {
+                    let mut node = Node::new();
+                    node.add_rule_(rest, value);
+                    self.next.insert(byte, node);
+                }
+                Some(node) => {
+                    node.add_rule_(rest, value);
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn build_decision_tree(rules: Vec<Rule>) -> TokenStream {
+    let mut stream = TokenStream::new();
+    let mut tree = Node::new();
+    for rule in rules {
+        tree.add_rule(rule);
+    }
+
+    stream.append_all(tree.to_token_stream());
+
+    stream
+}


### PR DESCRIPTION
Instead of linearly searching through a few dozen of items when a key
combination is pressed, we now generate a more efficient parser with
help of a proc macro for the combination. The generated function looks
at every byte in the input once. As an example of how this works, for
this declaration:

    byte_seq_parser! {
        example -> Key,

        [1, 2] => Key::Del,
        [1, 3] => Key::Home,
        [0] => Key::PageUp,
    }

This is the generated function

    fn example(buf: &[u8]) -> Option<(Key, usize)> {
        let mut i: usize = 0;
        match buf.get(i) {
            None => None,
            Some(byte) => match byte {
                1u8 => {
                    i += 1;
                    match buf.get(i) {
                        None => None,
                        Some(byte) => match byte {
                            3u8 => {
                                i += 1;
                                Some((Key::Home, i))
                            }
                            2u8 => {
                                i += 1;
                                Some((Key::Del, i))
                            }
                            _ => None,
                        },
                    }
                }
                0u8 => {
                    i += 1;
                    Some((Key::PageUp, i))
                }
                _ => None,
            },
        }
    }

(This way of matching a set of strings probably has a name, but I don't
know what it is!)