### PR TITLE
Added line number to log formatter. Closes #204

### DIFF
--- a/tiny/src/main.rs
+++ b/tiny/src/main.rs
@@ -15,6 +15,7 @@ use libtiny_logger::Logger;
 use libtiny_tui::{MsgTarget, TUI};
 use libtiny_ui::UI;
 
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::exit;
 
@@ -75,6 +76,19 @@ fn run(
 ) {
     env_logger::builder()
         .target(env_logger::Target::Stderr)
+        .format(|buf, record| {
+            let timestamp = buf.timestamp_seconds();
+
+            writeln!(
+                buf,
+                "[{}] {} [{}:{}] {}",
+                timestamp,
+                record.level(),
+                record.file().unwrap_or_default(),
+                record.line().unwrap_or_default(),
+                record.args()
+            )
+        })
         .init();
 
     // One task for each client to handle IRC events


### PR DESCRIPTION
Sample log line:
```
[2020-06-02T08:44:00Z] DEBUG [libtiny_logger/src/lib.rs:164] Trying to open log file: "/home/trevor/tiny_logs/chat.freenode.net_#trevsroom.txt"
```
I put brackets around the timestamp and source file path due to personal preference. Let me know if this should be reverted back to having everything in one set of brackets [ ]


Closes #204