### PR TITLE
Refactored line.rs height calculation and drawing.

### DIFF
--- a/libtiny_tui/src/input_area/input_line.rs
+++ b/libtiny_tui/src/input_area/input_line.rs
@@ -1,153 +1,7 @@
-use crate::{config::Colors, termbox, utils};
+use crate::{config::Colors, line_split::LineDataCache, termbox, utils};
 use std::{cmp::min, ops::RangeBounds, vec::Drain};
 use termbox_simple::Termbox;
 
-/// Cache that stores the state of InputLine's height calculation.
-/// `line_count` is used as the dirty bit to invalidate the cache.
-#[derive(Clone, Debug)]
-struct LineDataCache {
-    /// Indices to split on when we draw, not always whitespaces
-    split_indices: Vec<i32>,
-    /// The total number of lines (height) that will be rendered
-    line_count: Option<i32>,
-    /// The current width of InputArea. Used in determining if we need to invalidate due to resize.
-    width: i32,
-    /// The current width of the InputLine (may be shorter due to nickname)
-    line_width: i32,
-    /// Current nickname length. Used in determining if we need to invalidate due to resize.
-    nick_length: usize,
-    /// The index into InputLine::buffer of the last whitespace that we saw in calculate_height()
-    last_whitespace_idx: Option<i32>,
-    /// True if the last character was a whitespace character
-    prev_char_is_whitespace: bool,
-    /// The length of the current line that is being added to.
-    /// Used to determine when to wrap to the next line in calculate_height()
-    current_line_length: i32,
-}
-
-impl LineDataCache {
-    fn new() -> LineDataCache {
-        LineDataCache {
-            split_indices: Vec::new(),
-            line_count: None,
-            width: 0,
-            line_width: 0,
-            nick_length: 0,
-            last_whitespace_idx: None,
-            prev_char_is_whitespace: false,
-            current_line_length: 0,
-        }
-    }
-
-    /// Performs a check to see if the width or nickname length changed
-    /// which would require an invalidation of the cache and recalculation of
-    /// the InputLine height.
-    fn needs_resize(&self, width: i32, nick_length: usize) -> bool {
-        self.width != width || self.nick_length != nick_length
-    }
-
-    /// Sets `line_count` to `None`, which invalidates the cache.
-    fn set_dirty(&mut self) {
-        self.line_count = None;
-    }
-
-    /// Checks if the cache is invalidated by seeing if
-    /// `line_count` is `None`.
-    fn is_dirty(&self) -> bool {
-        self.line_count.is_none()
-    }
-
-    /// Resets the cache to a default state that requires
-    /// a height calculation.
-    fn reset(&mut self, width: i32, nick_length: usize) {
-        self.split_indices.clear();
-        self.line_count = None;
-        self.width = width;
-        self.nick_length = nick_length;
-        self.line_width = width - nick_length as i32;
-        self.last_whitespace_idx = None;
-        self.prev_char_is_whitespace = false;
-        self.current_line_length = 0;
-    }
-
-    fn get_line_count(&self) -> Option<usize> {
-        self.line_count.map(|c| c as usize)
-    }
-
-    /// Function that calculates the height of the `InputLine`.
-    /// and sets `split_indices` for drawing.
-    /// An `offset` allows for resuming the calculation - see InputLine::insert().
-    /// `offset` must be less than or equal to the current buffer size.
-    ///
-    /// Scans through the buffer in one pass to determine how many lines
-    /// will be needed to render the text with word wrapping.
-    /// If an offset is provided, it will continue the calculation
-    /// from the saved state and save the new line count in `line_count`.
-    fn calculate_height(&mut self, buffer: &[char], offset: usize) {
-        debug_assert!(offset <= buffer.len());
-        let mut temp_count = 1;
-        if let Some(line_count) = self.line_count {
-            temp_count = line_count;
-            // If we made space for the cursor, subtract it.
-            if self.current_line_length == self.line_width {
-                temp_count -= 1;
-            }
-        }
-        for (c, current_idx) in buffer.iter().skip(offset).zip(offset..) {
-            let current_idx = current_idx as i32;
-            self.current_line_length += 1;
-
-            if c.is_whitespace() {
-                // Splitting
-                if self.current_line_length > self.line_width {
-                    // we're on a whitespace so just go to next line
-                    temp_count += 1;
-                    // this character will be the first one on the next line
-                    self.current_line_length = 1;
-                    // nick is shown on the first line, set width to full width in the consecutive
-                    // lines
-                    self.line_width = self.width;
-                    // store index for drawing
-                    self.split_indices.push(current_idx);
-                }
-                // store whitespace for splitting
-                self.last_whitespace_idx = Some(current_idx);
-                self.prev_char_is_whitespace = true;
-            } else {
-                // Splitting
-                if self.current_line_length > self.line_width {
-                    // if the previous character was a whitespace, then we have a clean split
-                    if !self.prev_char_is_whitespace && self.last_whitespace_idx.is_some() {
-                        // move back to the last whitespace and get the length of the input that
-                        // will be on the next line
-                        self.current_line_length = current_idx - self.last_whitespace_idx.unwrap();
-                        // store index for drawing
-                        self.split_indices
-                            .push(self.last_whitespace_idx.unwrap() + 1);
-                    } else {
-                        // unclean split on non-whitespace
-                        self.current_line_length = 1;
-                        // store index for drawing
-                        self.split_indices.push(current_idx);
-                    }
-                    // invalidate whitespace since we split here
-                    self.last_whitespace_idx = None;
-                    // moved to next line
-                    temp_count += 1;
-                    // set width to full width
-                    self.line_width = self.width;
-                }
-                self.prev_char_is_whitespace = false;
-            }
-        }
-
-        // Last line length is `line_width`, make room for cursor
-        if self.current_line_length == self.line_width {
-            temp_count += 1;
-        }
-        self.line_count = Some(temp_count);
-    }
-}
 #[derive(Clone, Debug)]
 pub(crate) struct InputLine {
     /// Input buffer
@@ -163,7 +17,7 @@ impl InputLine {
     pub(crate) fn new() -> InputLine {
         InputLine {
             buffer: Vec::with_capacity(512),
-            line_data: LineDataCache::new(),
+            line_data: LineDataCache::new(true),
         }
     }
 
@@ -171,7 +25,7 @@ impl InputLine {
     pub(crate) fn from_buffer(buffer: Vec<char>) -> InputLine {
         InputLine {
             buffer,
-            line_data: LineDataCache::new(),
+            line_data: LineDataCache::new(true),
         }
     }
 
@@ -216,7 +70,8 @@ impl InputLine {
     pub(crate) fn insert(&mut self, idx: usize, element: char) {
         self.buffer.insert(idx, element);
         if idx == self.buffer.len() - 1 {
-            self.line_data.calculate_height(&self.buffer, idx);
+            self.line_data
+                .calculate_height(&mut self.buffer.iter().copied(), idx);
         } else {
             self.line_data.set_dirty();
         }
@@ -231,7 +86,8 @@ impl InputLine {
     pub(crate) fn calculate_height(&mut self, width: i32, nick_length: usize) -> usize {
         if self.line_data.is_dirty() || self.line_data.needs_resize(width, nick_length) {
             self.line_data.reset(width, nick_length);
-            self.line_data.calculate_height(&self.buffer, 0);
+            self.line_data
+                .calculate_height(&mut self.buffer.iter().copied(), 0);
         }
         self.line_data.get_line_count().unwrap()
     }
@@ -289,7 +145,7 @@ fn draw_line_wrapped(
             cursor_xychar = (pos_x, pos_y, c);
         }
     };
-    let mut split_indices_iter = line.line_data.split_indices.iter().copied().peekable();
+    let mut split_indices_iter = line.line_data.get_splits().iter().copied().peekable();
     for (char_idx, c) in line.buffer.iter().enumerate() {
         let mut style = colors.user_msg;
         // for autocompletion highlighting

--- a/libtiny_tui/src/lib.rs
+++ b/libtiny_tui/src/lib.rs
@@ -7,6 +7,7 @@ mod config;
 mod editor;
 mod exit_dialogue;
 mod input_area;
+mod line_split;
 mod messaging;
 #[doc(hidden)]
 // FIXME: This is "pub" to be able to use in an example

--- a/libtiny_tui/src/line_split.rs
+++ b/libtiny_tui/src/line_split.rs
@@ -1,0 +1,152 @@
+/// Cache that stores the state of a line's height calculation.
+/// `line_count` is used as the dirty bit to invalidate the cache.
+#[derive(Clone, Debug)]
+pub struct LineDataCache {
+    /// Indices to split on when we draw, not always whitespaces
+    split_indices: Vec<i32>,
+    /// The total number of lines (height) that will be rendered
+    line_count: Option<i32>,
+    /// The current width of InputArea. Used in determining if we need to invalidate due to resize.
+    width: i32,
+    /// The current width of the InputLine (may be shorter due to nickname)
+    line_width: i32,
+    /// Current nickname length. Used in determining if we need to invalidate due to resize.
+    nick_length: usize,
+    /// The index into InputLine::buffer of the last whitespace that we saw in calculate_height()
+    last_whitespace_idx: Option<i32>,
+    /// True if the last character was a whitespace character
+    prev_char_is_whitespace: bool,
+    /// The length of the current line that is being added to.
+    /// Used to determine when to wrap to the next line in calculate_height()
+    current_line_length: i32,
+    /// If the line of text has a cursor
+    has_cursor: bool,
+}
+
+impl LineDataCache {
+    pub fn new(has_cursor: bool) -> LineDataCache {
+        LineDataCache {
+            split_indices: Vec::new(),
+            line_count: None,
+            width: 0,
+            line_width: 0,
+            nick_length: 0,
+            last_whitespace_idx: None,
+            prev_char_is_whitespace: false,
+            current_line_length: 0,
+            has_cursor,
+        }
+    }
+
+    /// Performs a check to see if the width or nickname length changed
+    /// which would require an invalidation of the cache and recalculation of
+    /// the line height.
+    pub fn needs_resize(&self, width: i32, nick_length: usize) -> bool {
+        self.width != width || self.nick_length != nick_length
+    }
+
+    /// Sets `line_count` to `None`, which invalidates the cache.
+    pub fn set_dirty(&mut self) {
+        self.line_count = None;
+    }
+
+    /// Checks if the cache is invalidated by seeing if
+    /// `line_count` is `None`.
+    pub fn is_dirty(&self) -> bool {
+        self.line_count.is_none()
+    }
+
+    /// Resets the cache to a default state that requires
+    /// a height calculation.
+    pub fn reset(&mut self, width: i32, nick_length: usize) {
+        self.split_indices.clear();
+        self.line_count = None;
+        self.width = width;
+        self.nick_length = nick_length;
+        self.line_width = width - nick_length as i32;
+        self.last_whitespace_idx = None;
+        self.prev_char_is_whitespace = false;
+        self.current_line_length = 0;
+    }
+
+    pub fn get_line_count(&self) -> Option<usize> {
+        self.line_count.map(|c| c as usize)
+    }
+
+    pub fn get_splits(&self) -> &[i32] {
+        &self.split_indices
+    }
+
+    /// Function that calculates the height of the line.
+    /// and sets `split_indices` for drawing.
+    /// An `offset` allows for resuming the calculation - see InputLine::insert().
+    /// `offset` must be less than or equal to the current buffer size.
+    ///
+    /// Scans through the buffer in one pass to determine how many lines
+    /// will be needed to render the text with word wrapping.
+    /// If an offset is provided, it will continue the calculation
+    /// from the saved state and save the new line count in `line_count`.
+    pub fn calculate_height<I: Iterator<Item = char>>(&mut self, buffer: I, offset: usize) {
+        let mut temp_count = 1;
+        if let Some(line_count) = self.line_count {
+            temp_count = line_count;
+            // If we made space for the cursor, subtract it.
+            if self.has_cursor && self.current_line_length == self.line_width {
+                temp_count -= 1;
+            }
+        }
+        for (c, current_idx) in buffer.skip(offset).zip(offset..) {
+            let current_idx = current_idx as i32;
+            self.current_line_length += 1;
+
+            if c.is_whitespace() {
+                // Splitting
+                if self.current_line_length > self.line_width {
+                    // we're on a whitespace so just go to next line
+                    temp_count += 1;
+                    // this character will be the first one on the next line
+                    self.current_line_length = 1;
+                    // nick is shown on the first line, set width to full width in the consecutive
+                    // lines
+                    self.line_width = self.width;
+                    // store index for drawing
+                    self.split_indices.push(current_idx);
+                }
+                // store whitespace for splitting
+                self.last_whitespace_idx = Some(current_idx);
+                self.prev_char_is_whitespace = true;
+            } else {
+                // Splitting
+                if self.current_line_length > self.line_width {
+                    // if the previous character was a whitespace, then we have a clean split
+                    if !self.prev_char_is_whitespace && self.last_whitespace_idx.is_some() {
+                        // move back to the last whitespace and get the length of the input that
+                        // will be on the next line
+                        self.current_line_length = current_idx - self.last_whitespace_idx.unwrap();
+                        // store index for drawing
+                        self.split_indices
+                            .push(self.last_whitespace_idx.unwrap() + 1);
+                    } else {
+                        // unclean split on non-whitespace
+                        self.current_line_length = 1;
+                        // store index for drawing
+                        self.split_indices.push(current_idx);
+                    }
+                    // invalidate whitespace since we split here
+                    self.last_whitespace_idx = None;
+                    // moved to next line
+                    temp_count += 1;
+                    // set width to full width
+                    self.line_width = self.width;
+                }
+                self.prev_char_is_whitespace = false;
+            }
+        }
+
+        // Last line length is `line_width`, make room for cursor
+        if self.has_cursor && self.current_line_length == self.line_width {
+            temp_count += 1;
+        }
+        self.line_count = Some(temp_count);
+    }
+}

--- a/libtiny_tui/src/msg_area/mod.rs
+++ b/libtiny_tui/src/msg_area/mod.rs
@@ -50,7 +50,7 @@ impl MsgArea {
         self.lines_height = None;
     }
 
-    pub(crate) fn draw(&self, tb: &mut Termbox, colors: &Colors, pos_x: i32, pos_y: i32) {
+    pub(crate) fn draw(&mut self, tb: &mut Termbox, colors: &Colors, pos_x: i32, pos_y: i32) {
         // Where to render current line
         let mut row = pos_y + self.height - 1;
 
@@ -60,7 +60,7 @@ impl MsgArea {
         // Draw lines in reverse order
         let mut line_idx = (self.lines.len() as i32) - 1;
         while line_idx >= 0 && row >= pos_y {
-            let line = &self.lines[line_idx as usize];
+            let line = &mut self.lines[line_idx as usize];
             let line_height = line.rendered_height(self.width);
             debug_assert!(line_height > 0);
 
@@ -80,7 +80,7 @@ impl MsgArea {
             // How many lines to skip in the `Line` before rendering
             let render_from = max(0, pos_y - line_row);
 
-            line.draw(tb, colors, pos_x, line_row, render_from, height, self.width);
+            line.draw(tb, colors, pos_x, line_row, render_from, height);
             row = line_row - 1;
             line_idx -= 1;
             skip = 0;
@@ -101,7 +101,7 @@ impl MsgArea {
             Some(height) => height,
             None => {
                 let mut total_height = 0;
-                for line in &self.lines {
+                for line in &mut self.lines {
                     total_height += line.rendered_height(self.width);
                 }
                 self.lines_height = Some(total_height);


### PR DESCRIPTION
Reused LineDataCache. Basically a drop-in fix. 
I did have to manually go through each of the failing tests, because they weren't accurate to how text should get rendered.

Closes #202

- [x] Don't render whitespaces that are split on?