### PR TITLE
Fix $EDITOR support

### DIFF
--- a/libtiny_tui/src/editor.rs
+++ b/libtiny_tui/src/editor.rs
@@ -1,35 +1,53 @@
+//! This module implements some part of running $EDITOR to edit input. The other part is
+//! implemented at the top-level of the current crate (in `input_handler` task).
+//!
+//! Implementation is a little bit hacky: we need to give control of tty, stdout, and stdin to
+//! $EDITOR while still running the tokio event loop, to handle connection events. Here's how we
+//! implement this:
+//!
+//! - $EDITOR runs in a new thread to avoid blocking tokio event loop.
+//!
+//! - termbox implement a 'suspend' method that restores the terminal and stops using tty, until
+//!   'activate' is called. We can still use termbox methods as usual, but termbox doesn't really
+//!   draw anything. This way we don't need to stop rendering TUI when $EDITOR is running, we just
+//!   'suspend' termbox and keep running the TUI as usual in its own task.
+//!
+//! - We use a oneshot channel from the spawned $EDITOR thread to the TUI input handler task, to
+//!   send the result. When the channel is available (not `None`) it means $EDITOR is running and
+//!   we should not read stdin. So the stdin handler task just blocks on this channel when it is
+//!   available. This happens in `input_handler` task at the top-level of the crate.
+
 use termbox_simple::Termbox;
+use tokio::sync::oneshot;
 
 #[derive(Debug)]
-pub(crate) enum EditorError {
+pub(crate) enum Error {
     Io(::std::io::Error),
     Var(::std::env::VarError),
 }
 
-impl From<::std::io::Error> for EditorError {
-    fn from(err: ::std::io::Error) -> EditorError {
-        EditorError::Io(err)
+impl From<::std::io::Error> for Error {
+    fn from(err: ::std::io::Error) -> Error {
+        Error::Io(err)
     }
 }
 
-impl From<::std::env::VarError> for EditorError {
-    fn from(err: ::std::env::VarError) -> EditorError {
-        EditorError::Var(err)
+impl From<::std::env::VarError> for Error {
+    fn from(err: ::std::env::VarError) -> Error {
+        Error::Var(err)
     }
 }
 
-/// The user tried to paste the multi-line string passed as the argument. Run $EDITOR to edit a
-/// temporary file with the string as the contents. On exit, parse the final contents of the file
-/// (ignore comment lines), and send each line in the file as a message. Abort if any of the lines
-/// look like a command (e.g. `/msg ...`). I don't know what's the best way to handle commands in
-/// this context.
-///
-/// Ok(str) => final string to send
-/// Err(str) => err message to show
-///
-/// FIXME: Ideally this function should get a `Termbox` argument and return a new `Termbox` because
-/// we shutdown the current termbox instance and initialize it again after running $EDITOR.
-pub(crate) fn edit(tb: &mut Termbox, tf: String, str: &str) -> Result<Vec<String>, EditorError> {
+pub(crate) type Result<A> = ::std::result::Result<A, Error>;
+
+pub(crate) type ResultReceiver = oneshot::Receiver<Result<Vec<String>>>;
+
+pub(crate) fn run(
+    tb: &mut Termbox,
+    text_field_contents: &str,
+    pasted_text: &str,
+    rcv_editor_ret: &mut Option<ResultReceiver>,
+) -> Result<()> {
     use std::{
         io::{Read, Seek, SeekFrom, Write},
         process::Command,
@@ -45,38 +63,63 @@ pub(crate) fn edit(tb: &mut Termbox, tf: String, str: &str) -> Result<Vec<String
          # this file will be sent (ignoring these lines). Delete contents to abort the\n\
          # paste."
     )?;
-    write!(tmp_file, "{}", tf)?;
-    write!(tmp_file, "{}", str.replace('\r', "\n"))?;
+    write!(tmp_file, "{}", text_field_contents)?;
+    write!(tmp_file, "{}", pasted_text.replace('\r', "\n"))?;
 
+    let (snd_editor_ret, rcv_editor_ret_) = oneshot::channel();
+    *rcv_editor_ret = Some(rcv_editor_ret_);
+
+    // Will be activated by the input handler task after reading rcv_editor_ret
     tb.suspend();
-    let ret = Command::new(editor).arg(tmp_file.path()).status();
-    tb.activate();
 
-    let ret = ret?;
-    if !ret.success() {
-        return Ok(vec![]); // assume aborted
-    }
+    // At this point termbox is suspended (terminal settings restored), and the input handler task
+    // won't be reading term_input until it reads from rcv_editor_ret, so the editor has control
+    // over the tty, stdout, and stdin.
+    tokio::task::spawn_blocking(move || {
+        let ret = Command::new(editor).arg(tmp_file.path()).status();
+        let ret = match ret {
+            Err(io_err) => {
+                snd_editor_ret.send(Err(io_err.into())).unwrap();
+                return;
+            }
+            Ok(ret) => ret,
+        };
 
-    let mut tmp_file = tmp_file.into_file();
-    tmp_file.seek(SeekFrom::Start(0))?;
-
-    let mut file_contents = String::new();
-    tmp_file.read_to_string(&mut file_contents)?;
-
-    let mut filtered_lines = vec![];
-    for s in file_contents.lines() {
-        // Ignore if the char is '#'. To actually send a `#` add space.
-        // For empty lines, send " ".
-        let first_char = s.chars().next();
-        if first_char == Some('#') {
-            // skip this line
-            continue;
-        } else if s.is_empty() {
-            filtered_lines.push(" ".to_owned());
-        } else {
-            filtered_lines.push(s.to_owned());
+        if !ret.success() {
+            // Assume aborted
+            snd_editor_ret.send(Ok(vec![])).unwrap();
+            return;
         }
-    }
 
-    Ok(filtered_lines)
+        let mut tmp_file = tmp_file.into_file();
+        if let Err(io_err) = tmp_file.seek(SeekFrom::Start(0)) {
+            snd_editor_ret.send(Err(io_err.into())).unwrap();
+            return;
+        }
+
+        let mut file_contents = String::new();
+        if let Err(io_err) = tmp_file.read_to_string(&mut file_contents) {
+            snd_editor_ret.send(Err(io_err.into())).unwrap();
+            return;
+        }
+
+        let mut filtered_lines = vec![];
+        for s in file_contents.lines() {
+            // Ignore if the char is '#'. To actually send a `#` add space.
+            // For empty lines, send " ".
+            let first_char = s.chars().next();
+            if first_char == Some('#') {
+                // skip this line
+                continue;
+            } else if s.is_empty() {
+                filtered_lines.push(" ".to_owned());
+            } else {
+                filtered_lines.push(s.to_owned());
+            }
+        }
+
+        snd_editor_ret.send(Ok(filtered_lines)).unwrap();
+    });
+
+    Ok(())
 }

--- a/libtiny_tui/src/tests/mod.rs
+++ b/libtiny_tui/src/tests/mod.rs
@@ -70,7 +70,7 @@ fn expect_screen(screen: &str, tui: &TUI, w: u16, h: u16, caller: &'static Locat
 
 fn enter_string(tui: &mut TUI, s: &str) {
     for c in s.chars() {
-        tui.handle_input_event(Event::Key(Key::Char(c)));
+        tui.handle_input_event(Event::Key(Key::Char(c)), &mut None);
     }
 }
 
@@ -240,7 +240,7 @@ fn ctrl_w() {
          |< irc.server_1.org #chan      |";
     expect_screen(screen, &tui, 30, 3, Location::caller());
 
-    tui.handle_input_event(Event::Key(Key::Ctrl('w')));
+    tui.handle_input_event(Event::Key(Key::Ctrl('w')), &mut None);
     tui.draw();
 
     #[rustfmt::skip]
@@ -252,7 +252,7 @@ fn ctrl_w() {
     expect_screen(screen, &tui, 30, 3, Location::caller());
 
     println!("~~~~~~~~~~~~~~~~~~~~~~");
-    tui.handle_input_event(Event::Key(Key::Ctrl('w')));
+    tui.handle_input_event(Event::Key(Key::Ctrl('w')), &mut None);
     println!("~~~~~~~~~~~~~~~~~~~~~~");
     tui.draw();
 
@@ -273,7 +273,7 @@ fn ctrl_w() {
 
     expect_screen(screen, &tui, 30, 3, Location::caller());
 
-    tui.handle_input_event(Event::Key(Key::Ctrl('w')));
+    tui.handle_input_event(Event::Key(Key::Ctrl('w')), &mut None);
     tui.draw();
 
     #[rustfmt::skip]
@@ -305,11 +305,11 @@ fn test_text_field_wrap() {
 
     for _ in 0..37 {
         let event = term_input::Event::Key(Key::Char('a'));
-        tui.handle_input_event(event);
+        tui.handle_input_event(event, &mut None);
     }
     for _ in 0..5 {
         let event = term_input::Event::Key(Key::Char('b'));
-        tui.handle_input_event(event);
+        tui.handle_input_event(event, &mut None);
     }
 
     tui.draw();
@@ -351,7 +351,7 @@ fn test_text_field_wrap() {
     // the text field
     for _ in 0..6 {
         let event = term_input::Event::Key(Key::Backspace);
-        tui.handle_input_event(event);
+        tui.handle_input_event(event, &mut None);
     }
 
     tui.draw();
@@ -373,7 +373,7 @@ fn test_text_field_wrap() {
     tui.set_size(30, 8);
     for _ in 0..5 {
         let event = term_input::Event::Key(Key::Char('b'));
-        tui.handle_input_event(event);
+        tui.handle_input_event(event, &mut None);
     }
     tui.draw();
 
@@ -409,16 +409,16 @@ fn test_text_field_wrap() {
     // Wrapping on words - splits lines on whitespace
     for _ in 0..6 {
         let event = term_input::Event::Key(Key::Backspace);
-        tui.handle_input_event(event);
+        tui.handle_input_event(event, &mut None);
     }
     // InputLine cache gets invalidated after backspace, need to redraw to calculate.
     tui.draw();
     let event = term_input::Event::Key(Key::Char(' '));
-    tui.handle_input_event(event);
+    tui.handle_input_event(event, &mut None);
 
     for _ in 0..5 {
         let event = term_input::Event::Key(Key::Char('b'));
-        tui.handle_input_event(event);
+        tui.handle_input_event(event, &mut None);
     }
 
     tui.draw();

--- a/termbox/src/lib.rs
+++ b/termbox/src/lib.rs
@@ -18,6 +18,8 @@ pub const TB_UNDERLINE: u16 = 0x0200;
 pub struct Termbox {
     // Not available in test instances
     tty: Option<File>,
+    // Used to save `tty` on `suspend` and restore on `activate`
+    old_tty: Option<File>,
     old_term: libc::termios,
     term_width: u16,
     term_height: u16,
@@ -137,6 +139,7 @@ impl Termbox {
         front_buffer.clear(clear_fg, clear_bg);
         let mut termbox = Termbox {
             tty: Some(tty),
+            old_tty: None,
             old_term,
             term_width,
             term_height,
@@ -162,6 +165,7 @@ impl Termbox {
     pub fn init_test(w: u16, h: u16) -> Termbox {
         Termbox {
             tty: None,
+            old_tty: None,
             old_term: unsafe { std::mem::zeroed() },
             term_width: w,
             term_height: h,
@@ -191,6 +195,7 @@ impl Termbox {
     // HACKY
     pub fn suspend(&mut self) {
         self.flip_terms();
+        self.old_tty = self.tty.take();
 
         self.output_buffer
             .extend_from_slice(termion::cursor::Show.as_ref());
@@ -207,6 +212,7 @@ impl Termbox {
     // HACKY
     pub fn activate(&mut self) {
         self.flip_terms();
+        self.tty = self.old_tty.take();
 
         // T_ENTER_CA for xterm
         if let Some(ref mut tty) = self.tty {


### PR DESCRIPTION
Previously running $EDITOR would block tokio event loop, which causes
all kinds of panics, and timeouts in connections, see #185 as an
example.

We now run $EDITOR in a new thread, and stop reading stdin in the input
handler task during that. Also fixes termbox's suspend method, which
previously keps using tty after suspend.

See also module documentation of `editor`.

Fixes #185