### PR TITLE
InputArea/LineDataCache, fast remove character from end of input

### DIFF
--- a/libtiny_tui/src/input_area/input_line.rs
+++ b/libtiny_tui/src/input_area/input_line.rs
@@ -59,8 +59,14 @@ impl InputLine {
 
     /// Interface for Vec::remove()
     pub(crate) fn remove(&mut self, idx: usize) -> char {
-        self.line_data.set_dirty();
-        self.buffer.remove(idx)
+        // self.line_data.set_dirty();
+        let removed = self.buffer.remove(idx);
+        if idx == self.buffer.len() {
+            self.line_data.remove_one(&self.buffer, removed);
+        } else {
+            self.line_data.set_dirty();
+        }
+        removed
     }
 
     /// Interface for Vec::insert()
@@ -85,6 +91,7 @@ impl InputLine {
     /// buffer is wider than width and scrolling is off.
     pub(crate) fn calculate_height(&mut self, width: i32, nick_length: usize) -> usize {
         if self.line_data.is_dirty() || self.line_data.needs_resize(width, nick_length) {
+            debug!("Recalculating inputline height");
             self.line_data.reset(width, nick_length);
             self.line_data
                 .calculate_height(&mut self.buffer.iter().copied(), 0);

--- a/libtiny_tui/src/input_area/input_line.rs
+++ b/libtiny_tui/src/input_area/input_line.rs
@@ -58,11 +58,13 @@ impl InputLine {
     }
 
     /// Interface for Vec::remove()
+    /// When removing from the end of the buffer
+    /// we can use the saved state to quickly calculate if
+    /// we're moving to the previous line, without fully recalculating.
     pub(crate) fn remove(&mut self, idx: usize) -> char {
-        // self.line_data.set_dirty();
         let removed = self.buffer.remove(idx);
         if idx == self.buffer.len() {
-            self.line_data.remove_one(&self.buffer, removed);
+            self.line_data.reverse_by_one(&self.buffer, removed);
         } else {
             self.line_data.set_dirty();
         }

--- a/libtiny_tui/src/line_split.rs
+++ b/libtiny_tui/src/line_split.rs
@@ -13,12 +13,14 @@ pub struct LineDataCache {
     /// Current nickname length. Used in determining if we need to invalidate due to resize.
     nick_length: usize,
     /// The index into InputLine::buffer of the last whitespace that we saw in calculate_height()
-    last_whitespace_idx: Option<i32>,
+    last_whitespace_idx: Vec<Option<i32>>,
     /// True if the last character was a whitespace character
     prev_char_is_whitespace: bool,
     /// The length of the current line that is being added to.
     /// Used to determine when to wrap to the next line in calculate_height()
     current_line_length: i32,
+    /// A stack of each line length
+    line_lengths: Vec<i32>,
     /// If the line of text has a cursor
     has_cursor: bool,
 }
@@ -31,9 +33,10 @@ impl LineDataCache {
             width: 0,
             line_width: 0,
             nick_length: 0,
-            last_whitespace_idx: None,
+            last_whitespace_idx: Vec::new(),
             prev_char_is_whitespace: false,
             current_line_length: 0,
+            line_lengths: Vec::new(),
             has_cursor,
         }
     }
@@ -64,9 +67,10 @@ impl LineDataCache {
         self.width = width;
         self.nick_length = nick_length;
         self.line_width = width - nick_length as i32;
-        self.last_whitespace_idx = None;
+        self.last_whitespace_idx = Vec::new();
         self.prev_char_is_whitespace = false;
         self.current_line_length = 0;
+        self.line_lengths = Vec::new();
     }
 
     pub fn get_line_count(&self) -> Option<usize> {
@@ -104,6 +108,8 @@ impl LineDataCache {
                 if self.current_line_length > self.line_width {
                     // we're on a whitespace so just go to next line
                     temp_count += 1;
+                    // Save previous line length
+                    self.line_lengths.push(self.current_line_length - 1);
                     // this character will be the first one on the next line
                     self.current_line_length = 1;
                     // nick is shown on the first line, set width to full width in the consecutive
@@ -113,27 +119,32 @@ impl LineDataCache {
                     self.split_indices.push(current_idx);
                 }
                 // store whitespace for splitting
-                self.last_whitespace_idx = Some(current_idx);
+                self.last_whitespace_idx.push(Some(current_idx));
                 self.prev_char_is_whitespace = true;
             } else {
                 // Splitting
                 if self.current_line_length > self.line_width {
                     // if the previous character was a whitespace, then we have a clean split
-                    if !self.prev_char_is_whitespace && self.last_whitespace_idx.is_some() {
+                    let last_whitespace_idx = self.last_whitespace_idx.last().unwrap_or(&None);
+                    if !self.prev_char_is_whitespace && last_whitespace_idx.is_some() {
                         // move back to the last whitespace and get the length of the input that
                         // will be on the next line
-                        self.current_line_length = current_idx - self.last_whitespace_idx.unwrap();
+                        self.current_line_length = current_idx - last_whitespace_idx.unwrap();
+                        // Save the previous line length
+                        self.line_lengths
+                            .push(self.line_width - self.current_line_length);
                         // store index for drawing
-                        self.split_indices
-                            .push(self.last_whitespace_idx.unwrap() + 1);
+                        self.split_indices.push(last_whitespace_idx.unwrap() + 1);
                     } else {
+                        // Save previous line length
+                        self.line_lengths.push(self.current_line_length - 1);
                         // unclean split on non-whitespace
                         self.current_line_length = 1;
                         // store index for drawing
                         self.split_indices.push(current_idx);
                     }
                     // invalidate whitespace since we split here
-                    self.last_whitespace_idx = None;
+                    self.last_whitespace_idx.push(None);
                     // moved to next line
                     temp_count += 1;
                     // set width to full width
@@ -141,6 +152,91 @@ impl LineDataCache {
                 }
                 self.prev_char_is_whitespace = false;
             }
+        }
+
+        // Last line length is `line_width`, make room for cursor
+        if self.has_cursor && self.current_line_length == self.line_width {
+            temp_count += 1;
+        }
+        self.line_count = Some(temp_count);
+    }
+
+    /// Reverses the state of the LineDataCache by one step
+    /// Used for removing one character at the end of the buffer
+    pub fn remove_one(&mut self, buffer: &Vec<char>, removed_char: char) {
+        // subtract the cursor line if there is one
+        let mut temp_count = 1;
+        if let Some(line_count) = self.line_count {
+            temp_count = line_count;
+            // If we made space for the cursor, subtract it.
+            if self.has_cursor && self.current_line_length == self.line_width {
+                temp_count -= 1;
+            }
+        }
+        // if on the first line there will be no reversal of line wrapping
+        if temp_count == 1 {
+            if removed_char.is_whitespace() {
+                self.last_whitespace_idx.pop();
+            }
+            self.current_line_length -= 1;
+        } else {
+            if removed_char.is_whitespace() {
+                if self.current_line_length == 1 {
+                    trace!("removed a whitespace on beginning of line. going to previous line.");
+                    // if we're on the second line, then we need to reset to the first line, which
+                    // has the nickname on it
+                    if temp_count == 2 {
+                        self.line_width = self.width - self.nick_length as i32;
+                    }
+                    self.current_line_length = self.line_lengths.pop().unwrap();
+                    self.split_indices.pop();
+                    temp_count -= 1;
+                } else {
+                    self.current_line_length -= 1;
+                }
+                self.last_whitespace_idx.pop();
+            } else {
+                if self.current_line_length == 1 {
+                    trace!("removing non-whitespace on beginning of line. going to previous line.");
+                    if temp_count == 2 {
+                        self.line_width = self.width - self.nick_length as i32;
+                    }
+                    self.current_line_length = self.line_lengths.pop().unwrap();
+                    self.split_indices.pop();
+                    self.last_whitespace_idx.pop();
+                    temp_count -= 1;
+                } else {
+                    if let Some(last_line_length) = self.line_lengths.last() {
+                        let mut last_line_width = self.line_width;
+                        if temp_count == 2 {
+                            last_line_width = self.width - self.nick_length as i32;
+                        }
+                        // check to see if there's enough space on previous line to reverse word wrapping
+                        // -1 because we already removed a character
+                        if self.current_line_length - 1 + last_line_length < last_line_width {
+                            trace!("reversing word wrap");
+                            if temp_count == 2 {
+                                self.line_width = self.width - self.nick_length as i32;
+                            }
+                            self.current_line_length = self.line_width;
+                            self.line_lengths.pop();
+                            self.split_indices.pop();
+                            self.last_whitespace_idx.pop();
+                            temp_count -= 1;
+                        } else {
+                            trace!("subtracting non-whitespace");
+                            self.current_line_length -= 1;
+                        }
+                    } else {
+                        trace!("subtracting non-whitespace");
+                        self.current_line_length -= 1;
+                    }
+                }
+            }
+        }
+
+        if let Some(ch) = buffer.last() {
+            self.prev_char_is_whitespace = ch.is_whitespace();
         }
 
         // Last line length is `line_width`, make room for cursor

--- a/libtiny_tui/src/tests/mod.rs
+++ b/libtiny_tui/src/tests/mod.rs
@@ -412,7 +412,6 @@ fn test_text_field_wrap() {
         tui.handle_input_event(event, &mut None);
     }
     // InputLine cache gets invalidated after backspace, need to redraw to calculate.
-    tui.draw();
     let event = term_input::Event::Key(Key::Char(' '));
     tui.handle_input_event(event, &mut None);
 


### PR DESCRIPTION
This is the final requirement to close #208.

> Deleting from the end shouldn't require generating the state from scratch.

I added a function to `LineDataCache` called `reverse_by_one`, which rewinds the state by one "step" in the calculation of height (`calculate_height`). 

I had to add a field to `LineDataCache`, `line_lengths`, which stores the length of each line. These can vary in size due word wrapping.

The reversal is pretty procedural with a "fast-track" when there is only one line to begin with. There might be a way to simplify the conditional logic, but I haven't explored that due to added complexity (and because I don't know if there is a way to make it simpler :smile:). 

