### PR TITLE
CTCP VERSION message support

### DIFF
--- a/libtiny_client/examples/echo.rs
+++ b/libtiny_client/examples/echo.rs
@@ -1,6 +1,6 @@
 //! An echo bot that just repeats stuff sent to it (either in a channel or as PRIVMSG).
 
-use libtiny_client::{Client, Event, ServerInfo};
+use libtiny_client::{Client, ClientInfo, Event, ServerInfo};
 use libtiny_wire::{Cmd, Msg, MsgTarget, Pfx};
 
 use futures::stream::StreamExt;
@@ -42,13 +42,17 @@ fn main() {
 
     println!("{:?}", server_info);
 
+    let client_info = ClientInfo {
+        version: String::from("testing"),
+    };
+
     let mut runtime = tokio::runtime::Builder::new()
         .basic_scheduler()
         .enable_all()
         .build()
         .unwrap();
     let local = tokio::task::LocalSet::new();
-    local.block_on(&mut runtime, echo_bot_task(server_info));
+    local.block_on(&mut runtime, echo_bot_task(server_info, client_info));
 }
 
 fn show_usage() {
@@ -57,8 +61,8 @@ fn show_usage() {
 
 static NICK_SEP: [&str; 4] = [": ", ", ", ":", ","];
 
-async fn echo_bot_task(server_info: ServerInfo) {
-    let (mut client, mut rcv_ev) = Client::new(server_info);
+async fn echo_bot_task(server_info: ServerInfo, client_info: ClientInfo) {
+    let (mut client, mut rcv_ev) = Client::new(server_info, client_info);
 
     while let Some(ev) = rcv_ev.next().await {
         println!("Client event: {:?}", ev);

--- a/libtiny_client/src/lib.rs
+++ b/libtiny_client/src/lib.rs
@@ -135,7 +135,10 @@ pub struct Client {
 impl Client {
     /// Create a new client. Spawns two `tokio` tasks on the given `runtime`. If not given, tasks
     /// are created on the default executor using `tokio::spawn`.
-    pub fn new(server_info: ServerInfo, client_info: ClientInfo) -> (Client, mpsc::Receiver<Event>) {
+    pub fn new(
+        server_info: ServerInfo,
+        client_info: ClientInfo,
+    ) -> (Client, mpsc::Receiver<Event>) {
         connect(server_info, client_info)
     }
 

--- a/libtiny_client/src/state.rs
+++ b/libtiny_client/src/state.rs
@@ -200,6 +200,10 @@ impl StateInner {
                 snd_irc_msg.try_send(wire::pong(server)).unwrap();
             }
 
+            // CTCP automatic response
+            // Currently only used for VERSION message, but can support other
+            // messages, such as USERINFO or FINGER
+            // https://www.irchelp.org/protocol/ctcpspec.html
             PRIVMSG {
                 target, msg, ctcp, ..
             } => {

--- a/libtiny_client/src/state.rs
+++ b/libtiny_client/src/state.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use crate::utils;
-use crate::{Event, ServerInfo, ClientInfo};
+use crate::{ClientInfo, Event, ServerInfo};
 use libtiny_wire as wire;
-use libtiny_wire::{Msg, MsgTarget, CTCP, Pfx};
+use libtiny_wire::{Msg, MsgTarget, Pfx, CTCP};
 
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -200,11 +200,20 @@ impl StateInner {
                 snd_irc_msg.try_send(wire::pong(server)).unwrap();
             }
 
-            PRIVMSG { target, ctcp, .. } => {
+            PRIVMSG {
+                target, msg, ctcp, ..
+            } => {
                 if let Some(ctcp) = ctcp {
                     if let CTCP::Version = ctcp {
-                        if let MsgTarget::User(target) = target {
-                            snd_irc_msg.try_send(wire::version_reply(target, &self.client_info.version)).unwrap();
+                        if msg.is_empty() {
+                            if let MsgTarget::User(target) = target {
+                                snd_irc_msg
+                                    .try_send(wire::version_reply(
+                                        target,
+                                        &self.client_info.version,
+                                    ))
+                                    .unwrap();
+                            }
                         }
                     }
                 }

--- a/libtiny_wire/src/lib.rs
+++ b/libtiny_wire/src/lib.rs
@@ -54,6 +54,16 @@ pub fn action(msgtarget: &str, msg: &str) -> String {
     format!("PRIVMSG {} :\x01ACTION {}\x01\r\n", msgtarget, msg)
 }
 
+pub fn version(msgtarget: &str) -> String {
+    assert!(msgtarget.len() + 21 <= 512); // See comments in `privmsg`
+    format!("PRIVMSG {} :\x01VERSION\x01\r\n", msgtarget)
+}
+
+pub fn version_reply(msgtarget: &str, version: &str) -> String {
+    assert!(msgtarget.len() + 21 <= 512); // See comments in `privmsg`
+    format!("NOTICE {} :\x01VERSION {}\x01\r\n", msgtarget, version)
+}
+
 pub fn away(msg: Option<&str>) -> String {
     match msg {
         None => "AWAY\r\n".to_string(),

--- a/tiny/src/cli.rs
+++ b/tiny/src/cli.rs
@@ -15,13 +15,19 @@ pub(crate) struct Args {
     pub(crate) config_path: Option<PathBuf>,
 }
 
-/// Parses command line arguments.
-pub(crate) fn parse() -> Args {
+/// Gets the current version of Tiny and git commit hash if available
+pub(crate) fn get_version() -> String {
     let mut version = crate_version!().to_owned();
     let commit_hash = env!("GIT_HASH");
     if !commit_hash.is_empty() {
         version = format!("{} ({})", version, commit_hash);
     }
+    version
+}
+
+/// Parses command line arguments.
+pub(crate) fn parse() -> Args {
+    let version = get_version();
 
     let m = App::new(crate_name!())
         .version(version.as_str())

--- a/tiny/src/cmd.rs
+++ b/tiny/src/cmd.rs
@@ -3,7 +3,7 @@
 
 use crate::config;
 use crate::utils;
-use libtiny_client::{Client, ServerInfo};
+use libtiny_client::{Client, ServerInfo, ClientInfo};
 use libtiny_ui::{MsgSource, MsgTarget, UI};
 use std::path::Path;
 
@@ -96,7 +96,7 @@ fn find_client<'a>(clients: &'a mut Vec<Client>, serv_name: &str) -> Option<&'a 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static CMDS: [&Cmd; 8] = [
+static CMDS: [&Cmd; 9] = [
     &AWAY_CMD,
     &CLOSE_CMD,
     &CONNECT_CMD,
@@ -105,6 +105,7 @@ static CMDS: [&Cmd; 8] = [
     &MSG_CMD,
     &NAMES_CMD,
     &NICK_CMD,
+    &VERSION_CMD,
 ];
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -258,7 +259,11 @@ fn connect_(
         auto_join: defaults.join.clone(),
         nickserv_ident: None,
         sasl_auth: None,
-    });
+    },
+    ClientInfo {
+        version: crate::get_tiny_version()
+    }
+);
 
     // Spawn UI task
     let ui_clone = libtiny_ui::clone_box(&**ui);
@@ -455,6 +460,31 @@ fn nick(args: CmdArgs) {
         }
     } else {
         ui.add_client_err_msg("/nick usage: /nick <nick>", &MsgTarget::CurrentTab);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static VERSION_CMD: Cmd = Cmd {
+    name: "version",
+    cmd_fn: version,
+};
+
+fn version(args: CmdArgs) {
+    let CmdArgs {
+        args,
+        ui,
+        clients,
+        src,
+        ..
+    } = args;
+    let target: Vec<&str> = args.split_whitespace().collect();
+    if target.len() == 1 {
+        if let Some(client) = find_client(clients, src.serv_name()) {
+            client.version(target[0]);
+        }
+    } else {
+        ui.add_client_err_msg("/version usage: /version <server|nick>", &MsgTarget::CurrentTab);
     }
 }
 

--- a/tiny/src/cmd.rs
+++ b/tiny/src/cmd.rs
@@ -486,7 +486,7 @@ fn version(args: CmdArgs) {
         }
     } else {
         ui.add_client_err_msg(
-            "/version usage: /version <server|nick>",
+            "/version usage: /version <nick>",
             &MsgTarget::CurrentTab,
         );
     }

--- a/tiny/src/cmd.rs
+++ b/tiny/src/cmd.rs
@@ -3,7 +3,7 @@
 
 use crate::config;
 use crate::utils;
-use libtiny_client::{Client, ServerInfo, ClientInfo};
+use libtiny_client::{Client, ClientInfo, ServerInfo};
 use libtiny_ui::{MsgSource, MsgTarget, UI};
 use std::path::Path;
 
@@ -249,21 +249,22 @@ fn connect_(
     let msg_target = MsgTarget::Server { serv: serv_name };
     ui.add_client_msg("Connecting...", &msg_target);
 
-    let (client, rcv_ev) = Client::new(ServerInfo {
-        addr: serv_name.to_owned(),
-        port: serv_port,
-        tls: defaults.tls,
-        realname: defaults.realname.clone(),
-        pass: pass.map(str::to_owned),
-        nicks: defaults.nicks.clone(),
-        auto_join: defaults.join.clone(),
-        nickserv_ident: None,
-        sasl_auth: None,
-    },
-    ClientInfo {
-        version: crate::get_tiny_version()
-    }
-);
+    let (client, rcv_ev) = Client::new(
+        ServerInfo {
+            addr: serv_name.to_owned(),
+            port: serv_port,
+            tls: defaults.tls,
+            realname: defaults.realname.clone(),
+            pass: pass.map(str::to_owned),
+            nicks: defaults.nicks.clone(),
+            auto_join: defaults.join.clone(),
+            nickserv_ident: None,
+            sasl_auth: None,
+        },
+        ClientInfo {
+            version: crate::get_tiny_version(),
+        },
+    );
 
     // Spawn UI task
     let ui_clone = libtiny_ui::clone_box(&**ui);
@@ -484,7 +485,10 @@ fn version(args: CmdArgs) {
             client.version(target[0]);
         }
     } else {
-        ui.add_client_err_msg("/version usage: /version <server|nick>", &MsgTarget::CurrentTab);
+        ui.add_client_err_msg(
+            "/version usage: /version <server|nick>",
+            &MsgTarget::CurrentTab,
+        );
     }
 }
 

--- a/tiny/src/conn.rs
+++ b/tiny/src/conn.rs
@@ -149,7 +149,7 @@ fn handle_irc_msg(ui: &dyn UI, client: &Client, msg: wire::Msg) {
                     MsgTarget::Server { serv }
                 };
                 ui.add_client_msg(
-                    &format!("Received version request from {}", origin),
+                    &format!("Received version request from {}, {}", origin,  msg),
                     &msg_target,
                 );
                 return;

--- a/tiny/src/conn.rs
+++ b/tiny/src/conn.rs
@@ -148,10 +148,14 @@ fn handle_irc_msg(ui: &dyn UI, client: &Client, msg: wire::Msg) {
                 } else {
                     MsgTarget::Server { serv }
                 };
-                ui.add_client_msg(
-                    &format!("Received version request from {}, {}", origin,  msg),
-                    &msg_target,
-                );
+                if msg.is_empty() {
+                    ui.add_client_msg(
+                        &format!("Received version request from {}", origin),
+                        &msg_target,
+                    );
+                } else {
+                    ui.add_client_msg(&format!("{} is on {}", origin, msg), &msg_target);
+                }
                 return;
             }
 

--- a/tiny/src/main.rs
+++ b/tiny/src/main.rs
@@ -10,7 +10,7 @@ mod conn;
 mod ui;
 mod utils;
 
-use libtiny_client::{Client, ServerInfo};
+use libtiny_client::{Client, ServerInfo, ClientInfo};
 use libtiny_logger::{Logger, LoggerInitError};
 use libtiny_tui::{MsgTarget, TUI};
 use libtiny_ui::UI;
@@ -162,7 +162,10 @@ fn run(
                 }),
             };
 
-            let (client, rcv_conn_ev) = Client::new(server_info);
+            let client_info = ClientInfo {
+                version: get_tiny_version()
+            };
+            let (client, rcv_conn_ev) = Client::new(server_info, client_info);
             // TODO: Somehow it's quite hard to expose this objekt call with a different name and less
             // polymorphic type in libtiny_ui ...
             let tui_clone = libtiny_ui::clone_box(&*tui);
@@ -179,4 +182,8 @@ fn run(
     });
 
     runtime.block_on(local);
+}
+
+pub(crate) fn get_tiny_version() -> String {
+    format!("tiny {}", crate::cli::get_version())
 }

--- a/tiny/src/main.rs
+++ b/tiny/src/main.rs
@@ -10,7 +10,7 @@ mod conn;
 mod ui;
 mod utils;
 
-use libtiny_client::{Client, ServerInfo, ClientInfo};
+use libtiny_client::{Client, ClientInfo, ServerInfo};
 use libtiny_logger::{Logger, LoggerInitError};
 use libtiny_tui::{MsgTarget, TUI};
 use libtiny_ui::UI;
@@ -163,7 +163,7 @@ fn run(
             };
 
             let client_info = ClientInfo {
-                version: get_tiny_version()
+                version: get_tiny_version(),
             };
             let (client, rcv_conn_ev) = Client::new(server_info, client_info);
             // TODO: Somehow it's quite hard to expose this objekt call with a different name and less


### PR DESCRIPTION
- Added `ClientInfo` to `Client` which stores the client's version.
- Added a  `/version <nick>` command that sends a request for that nick's version
- Handle the response to `/version`
- Now we respond to other user's asking us for which version we're on
___
Unrelated:
- Refactored some of the command usages
- Added `/help`

Closes #145 