### PR TITLE
Fallback to prefix for server name parsing of RPL_YOURHOST reply

### DIFF
--- a/libtiny_client/src/state.rs
+++ b/libtiny_client/src/state.rs
@@ -480,7 +480,7 @@ impl StateInner {
 
                 // An example <servername>: cherryh.freenode.net[149.56.134.238/8001]
 
-                match parse_servername(pfx, params) {
+                match parse_servername(pfx.as_ref(), params) {
                     None => {
                         error!("Could not parse server name in 002 RPL_YOURHOST message.");
                     }
@@ -736,7 +736,7 @@ fn parse_yourhost_msg(params: &[String]) -> Option<String> {
 }
 
 /// Parse the server name from prefix
-fn parse_server_pfx(pfx: &Option<Pfx>) -> Option<String> {
+fn parse_server_pfx(pfx: Option<&Pfx>) -> Option<String> {
     if let Some(Pfx::Server(server_name)) = pfx {
         Some(server_name.to_owned())
     } else {
@@ -746,7 +746,7 @@ fn parse_server_pfx(pfx: &Option<Pfx>) -> Option<String> {
 
 /// Parse server name from RPL_YOURHOST reply
 /// or fallback to using the server name inside Pfx::Server
-fn parse_servername(pfx: &Option<Pfx>, params: &[String]) -> Option<String> {
+fn parse_servername(pfx: Option<&Pfx>, params: &[String]) -> Option<String> {
     parse_yourhost_msg(&params).or_else(|| parse_server_pfx(pfx))
 }
 
@@ -755,22 +755,10 @@ fn parse_servername(pfx: &Option<Pfx>, params: &[String]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn test_parse_servername_1() {
-        // Gitter variation
-        // Msg { pfx: Some(Server("irc.gitter.im")), cmd: Reply { num: 2, params: ["nickname", " 1.10.0"] } }
-        let prefix = Some(Pfx::Server("irc.gitter.im".to_string()));
-        let params = vec!["nickname".to_string(), "1.0".to_string()];
-        assert_eq!(
-            parse_servername(&prefix, &params),
-            Some("irc.gitter.im".to_owned())
-        );
-    }
 
     #[test]
-    fn test_parse_servername_2() {
+    fn test_parse_servername_1() {
         // IRC standard
-        // Msg { pfx: Some(Server("card.freenode.net")), cmd: Reply { num: 2, params: ["nickname", "Your host is card.freenode.net[38.229.70.22/6697], running version ircd-seven-1.1.9"] } }
         let prefix = Some(Pfx::Server("card.freenode.net".to_string()));
         let params = vec![
             "nickname".to_string(),
@@ -778,8 +766,40 @@ mod tests {
                 .to_string(),
         ];
         assert_eq!(
-            parse_servername(&prefix, &params),
+            parse_servername(prefix.as_ref(), &params),
             Some("card.freenode.net".to_owned())
+        );
+
+        let prefix = Some(Pfx::Server("coulomb.oftc.net".to_string()));
+        let params = vec![
+            "nickname".to_string(),
+            "Your host is coulomb.oftc.net[109.74.200.93/6697], running version hybrid-7.2.2+oftc1.7.3".to_string(),
+        ];
+        assert_eq!(
+            parse_servername(prefix.as_ref(), &params),
+            Some("coulomb.oftc.net".to_owned())
+        );
+
+        let prefix = Some(Pfx::Server("irc.eagle.y.se".to_string()));
+        let params = vec![
+            "nickname".to_string(),
+            "Your host is irc.eagle.y.se, running version UnrealIRCd-4.0.18".to_string(),
+        ];
+        assert_eq!(
+            parse_servername(prefix.as_ref(), &params),
+            Some("irc.eagle.y.se".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_parse_servername_2() {
+        // Gitter variation
+        // Msg { pfx: Some(Server("irc.gitter.im")), cmd: Reply { num: 2, params: ["nickname", " 1.10.0"] } }
+        let prefix = Some(Pfx::Server("irc.gitter.im".to_string()));
+        let params = vec!["nickname".to_string(), " 1.10.0".to_string()];
+        assert_eq!(
+            parse_servername(prefix.as_ref(), &params),
+            Some("irc.gitter.im".to_owned())
         );
     }
 }

--- a/libtiny_client/src/state.rs
+++ b/libtiny_client/src/state.rs
@@ -474,13 +474,13 @@ impl StateInner {
             //
             // RPL_YOURHOST, set servername
             //
-            Reply { num: 002, .. } => {
+            Reply { num: 002, params } => {
                 // 002    RPL_YOURHOST
                 //        "Your host is <servername>, running version <ver>"
 
                 // An example <servername>: cherryh.freenode.net[149.56.134.238/8001]
 
-                match parse_servername(msg) {
+                match parse_servername(pfx, params) {
                     None => {
                         error!("Could not parse server name in 002 RPL_YOURHOST message.");
                     }
@@ -736,7 +736,7 @@ fn parse_yourhost_msg(params: &[String]) -> Option<String> {
 }
 
 /// Parse the server name from prefix
-fn parse_server_pfx(pfx: Option<&Pfx>) -> Option<String> {
+fn parse_server_pfx(pfx: &Option<Pfx>) -> Option<String> {
     if let Some(Pfx::Server(server_name)) = pfx {
         Some(server_name.to_owned())
     } else {
@@ -746,13 +746,8 @@ fn parse_server_pfx(pfx: Option<&Pfx>) -> Option<String> {
 
 /// Parse server name from RPL_YOURHOST reply
 /// or fallback to using the server name inside Pfx::Server
-fn parse_servername(msg: &Msg) -> Option<String> {
-    use wire::Cmd::Reply;
-    if let Reply { params, .. } = &msg.cmd {
-        parse_yourhost_msg(&params).or(parse_server_pfx(msg.pfx.as_ref()))
-    } else {
-        parse_server_pfx(msg.pfx.as_ref())
-    }
+fn parse_servername(pfx: &Option<Pfx>, params: &[String]) -> Option<String> {
+    parse_yourhost_msg(&params).or_else(|| parse_server_pfx(pfx))
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -760,32 +755,31 @@ fn parse_servername(msg: &Msg) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wire::Cmd::*;
     #[test]
     fn test_parse_servername_1() {
         // Gitter variation
         // Msg { pfx: Some(Server("irc.gitter.im")), cmd: Reply { num: 2, params: ["nickname", " 1.10.0"] } }
-        let msg = Msg {
-            pfx: Some(Pfx::Server("irc.gitter.im".to_string())),
-            cmd: Reply {
-                num: 2,
-                params: vec!["nickname".to_string(), "1.0".to_string()],
-            },
-        };
-        assert_eq!(parse_servername(&msg), Some("irc.gitter.im".to_owned()));
+        let prefix = Some(Pfx::Server("irc.gitter.im".to_string()));
+        let params = vec!["nickname".to_string(), "1.0".to_string()];
+        assert_eq!(
+            parse_servername(&prefix, &params),
+            Some("irc.gitter.im".to_owned())
+        );
     }
 
     #[test]
     fn test_parse_servername_2() {
         // IRC standard
         // Msg { pfx: Some(Server("card.freenode.net")), cmd: Reply { num: 2, params: ["nickname", "Your host is card.freenode.net[38.229.70.22/6697], running version ircd-seven-1.1.9"] } }
-        let msg = Msg {
-            pfx: Some(Pfx::Server("card.freenode.net".to_string())),
-            cmd: Reply {
-                num: 2,
-                params: vec!["nickname".to_string(), "Your host is card.freenode.net[38.229.70.22/6697], running version ircd-seven-1.1.9".to_string()]
-            }
-        };
-        assert_eq!(parse_servername(&msg), Some("card.freenode.net".to_owned()));
+        let prefix = Some(Pfx::Server("card.freenode.net".to_string()));
+        let params = vec![
+            "nickname".to_string(),
+            "Your host is card.freenode.net[38.229.70.22/6697], running version ircd-seven-1.1.9"
+                .to_string(),
+        ];
+        assert_eq!(
+            parse_servername(&prefix, &params),
+            Some("card.freenode.net".to_owned())
+        );
     }
 }

--- a/libtiny_client/src/state.rs
+++ b/libtiny_client/src/state.rs
@@ -723,7 +723,7 @@ async fn retry_channel_join(
 const SERVERNAME_PREFIX: &str = "Your host is ";
 const SERVERNAME_PREFIX_LEN: usize = SERVERNAME_PREFIX.len();
 
-/// Try to parse servername in a 002 RPL_YOURHOST reply
+/// Try to parse servername in a 002 RPL_YOURHOST reply params.
 fn parse_yourhost_msg(params: &[String]) -> Option<String> {
     let msg = params.get(1).or_else(|| params.get(0))?;
     if msg.len() >= SERVERNAME_PREFIX_LEN && &msg[..SERVERNAME_PREFIX_LEN] == SERVERNAME_PREFIX {
@@ -735,7 +735,7 @@ fn parse_yourhost_msg(params: &[String]) -> Option<String> {
     }
 }
 
-/// Parse the server name from prefix
+/// Get the server name from a prefix.
 fn parse_server_pfx(pfx: Option<&Pfx>) -> Option<String> {
     if let Some(Pfx::Server(server_name)) = pfx {
         Some(server_name.to_owned())
@@ -744,8 +744,8 @@ fn parse_server_pfx(pfx: Option<&Pfx>) -> Option<String> {
     }
 }
 
-/// Parse server name from RPL_YOURHOST reply
-/// or fallback to using the server name inside Pfx::Server
+/// Parse server name from RPL_YOURHOST reply or fallback to using the server name inside
+/// Pfx::Server. See https://www.irc.com/dev/docs/refs/numerics/002.html for more info.
 fn parse_servername(pfx: Option<&Pfx>, params: &[String]) -> Option<String> {
     parse_yourhost_msg(&params).or_else(|| parse_server_pfx(pfx))
 }


### PR DESCRIPTION
Falling back to getting the server name from the prefix, since some IRC servers don't comply with the standard. 

Recommended by https://www.irc.com/dev/docs/refs/numerics/002.html

> The \<servername\> may also include other information depending on the server software, for example irc.example.com[203.0.113.15/6667], so we instead recommend relying on the prefix or the RPL_MYINFO (004) numeric if knowing the current server hostname is desired.



Closes #239