### PR TITLE
Use bencher crate for benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "bencher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +417,7 @@ dependencies = [
 name = "libtiny_tui"
 version = "0.1.0"
 dependencies = [
+ "bencher",
  "futures",
  "libc",
  "libtiny_ui",

--- a/libtiny_tui/Cargo.toml
+++ b/libtiny_tui/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 description = "A terminal UI for tiny"
 edition = "2018"
 
+[[bench]]
+name = "bench"
+harness = false
+
 [features]
 default = []
 desktop-notifications = ["notify-rust"]
@@ -22,5 +26,6 @@ time = "0.1"
 tokio = { version = "0.2.22", default-features = false, features = ["sync", "rt-core", "rt-util", "blocking", "signal", "stream", "time"] }
 
 [dev-dependencies]
-libc = "0.2.22"
-mio = "0.6.9"
+bencher = "0.1"
+libc = "0.2"
+mio = "0.6"

--- a/libtiny_tui/benches/bench.rs
+++ b/libtiny_tui/benches/bench.rs
@@ -1,0 +1,170 @@
+#[macro_use]
+extern crate bencher;
+
+use bencher::Bencher;
+use std::{fs::File, io::BufRead, io::BufReader, io::Read};
+use time::Tm;
+
+use libtiny_tui::trie::Trie;
+use libtiny_tui::tui::TUI;
+use libtiny_tui::MsgTarget;
+
+static DICT_FILE: &str = "/usr/share/dict/american-english";
+
+fn trie_build(b: &mut Bencher) {
+    // Total words: 305,089
+    // 117,701,680 ns (0.1 seconds)
+    // (before reversing the list: 116,795,268 ns (0.1 seconds))
+
+    let mut contents = String::new();
+    let mut words: Vec<&str> = vec![];
+    {
+        match File::open(DICT_FILE) {
+            Err(_) => {
+                println!("Can't open dictionary file, aborting benchmark.");
+                return;
+            }
+            Ok(mut file) => {
+                file.read_to_string(&mut contents).unwrap();
+                words.extend(contents.lines());
+            }
+        }
+    }
+
+    b.iter(|| {
+        let mut trie = Trie::new();
+        // Note that we insert the words in reverse order here. Since the
+        // dictionary is already sorted, we end up benchmarking the best case.
+        // Since that best case is never really happens in practice, the number
+        // is practically useless. Worst case is at least giving an upper bound.
+        for word in words.iter().rev() {
+            trie.insert(word);
+        }
+        trie
+    });
+}
+
+fn hashset_build(b: &mut Bencher) {
+    // Total words: 305,089
+    // 40,292,006 ns (0.04 seconds)
+
+    use std::collections::HashSet;
+
+    let mut contents = String::new();
+    let mut words: Vec<&str> = vec![];
+    {
+        let mut file = File::open(DICT_FILE).unwrap();
+        file.read_to_string(&mut contents).unwrap();
+        words.extend(contents.lines());
+    }
+
+    b.iter(|| {
+        let mut set = HashSet::new();
+        for word in words.iter() {
+            set.insert(word);
+        }
+        set
+    });
+}
+
+fn trie_lookup(b: &mut Bencher) {
+    // Total:     305,089 words
+    // Returning:     235 words
+    // 140,717 ns (0.14 ms)
+
+    let mut contents = String::new();
+    let mut words: Vec<&str> = vec![];
+    {
+        match File::open(DICT_FILE) {
+            Err(_) => {
+                println!("Can't open dictionary file, aborting benchmark.");
+                return;
+            }
+            Ok(mut file) => {
+                file.read_to_string(&mut contents).unwrap();
+                words.extend(contents.lines());
+            }
+        }
+    }
+
+    let mut trie = Trie::new();
+    for word in words {
+        trie.insert(word);
+    }
+
+    b.iter(|| trie.drop_pfx(&mut "abs".chars()));
+}
+
+fn trie_list_all(b: &mut Bencher) {
+    // Total:     305,089 words
+    // Returning: 305,089 words
+    // 205,946,060 ns (0.2 s)
+
+    let mut contents = String::new();
+    let mut words: Vec<&str> = vec![];
+    {
+        match File::open(DICT_FILE) {
+            Err(_) => {
+                println!("Can't open dictionary file, aborting benchmark.");
+                return;
+            }
+            Ok(mut file) => {
+                file.read_to_string(&mut contents).unwrap();
+                words.extend(contents.lines());
+            }
+        }
+    }
+
+    let mut trie = Trie::new();
+    for word in words {
+        trie.insert(word);
+    }
+
+    b.iter(|| trie.drop_pfx(&mut "".chars()));
+}
+
+fn tui_resize(b: &mut Bencher) {
+    let mut tui = TUI::new_test(80, 50);
+
+    let server = "<server>";
+    tui.new_server_tab(server, None);
+
+    let ts: Tm = unsafe { ::std::mem::zeroed() };
+    let target = MsgTarget::CurrentTab;
+
+    let f = File::open("test/lipsum.txt").unwrap();
+    let f = BufReader::new(f);
+    for line in f.lines() {
+        let line = line.unwrap();
+        tui.add_msg(&line, ts, &target);
+    }
+
+    b.iter(|| {
+        let mut w = 80;
+        let mut h = 50;
+
+        for _ in 0..50 {
+            w -= 1;
+            h -= 1;
+            tui.set_size(w, h);
+            tui.draw();
+        }
+
+        for _ in 0..50 {
+            w += 1;
+            h += 1;
+            tui.set_size(w, h);
+            tui.draw();
+        }
+    });
+}
+
+benchmark_group!(
+    benches,
+    trie_build,
+    hashset_build,
+    trie_lookup,
+    trie_list_all,
+    tui_resize
+);
+benchmark_main!(benches);

--- a/libtiny_tui/src/lib.rs
+++ b/libtiny_tui/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(test, feature(test))]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::cognitive_complexity)]
 #![feature(or_patterns)]
@@ -10,14 +9,15 @@ mod input_area;
 mod line_split;
 mod messaging;
 #[doc(hidden)]
-// FIXME: This is "pub" to be able to use in an example
-pub mod msg_area;
+pub mod msg_area; // Public to be able to use in an example
 mod notifier;
 mod statusline;
 mod tab;
 mod termbox;
-mod trie;
-mod tui;
+#[doc(hidden)]
+pub mod trie; // Public for benchmarks
+#[doc(hidden)]
+pub mod tui; // Public for benchmarks
 mod utils;
 mod widget;
 

--- a/libtiny_tui/src/msg_area/line.rs
+++ b/libtiny_tui/src/msg_area/line.rs
@@ -253,11 +253,8 @@ fn irc_color_to_termbox(irc_color: u8) -> u8 {
 #[cfg(test)]
 mod tests {
 
-    extern crate test;
-
     use super::*;
     use std::{fs::File, io::Read};
-    use test::Bencher;
 
     #[test]
     fn height_test_1() {
@@ -336,23 +333,5 @@ mod tests {
         // lipsum.txt has 1160 words in it. each line should contain at most one
         // word so we should have 1160 lines.
         assert_eq!(line.rendered_height(80), 102);
-    }
-
-    #[bench]
-    fn bench_rendered_height(b: &mut Bencher) {
-        // 1160 words, 2,237 ns/iter (+/- 150)
-
-        let mut text = String::new();
-        {
-            let mut file = File::open("test/lipsum.txt").unwrap();
-            file.read_to_string(&mut text).unwrap();
-        }
-
-        let mut line = Line::new();
-        line.add_text(&text);
-        b.iter(|| {
-            line.force_recalculation();
-            line.rendered_height(1)
-        });
     }
 } // mod tests

--- a/libtiny_tui/src/tui.rs
+++ b/libtiny_tui/src/tui.rs
@@ -2,9 +2,9 @@
 #![allow(clippy::new_without_default)]
 #![allow(clippy::too_many_arguments)]
 
+use std::cmp::Ordering;
 use std::path::PathBuf;
-use std::str;
-use std::str::SplitWhitespace;
+use std::str::{self, SplitWhitespace};
 use time::Tm;
 
 use crate::config::{parse_config, Colors, Config, Style};
@@ -74,7 +74,7 @@ const TUI_COMMANDS: [CmdUsage; 6] = [
     RELOAD_CMD,
 ];
 
-pub(crate) struct TUI {
+pub struct TUI {
     /// Termbox instance
     tb: Termbox,
 
@@ -104,8 +104,7 @@ impl TUI {
         TUI::new_tb(Some(config_path), tb)
     }
 
-    #[cfg(test)]
-    pub(crate) fn new_test(w: u16, h: u16) -> TUI {
+    pub fn new_test(w: u16, h: u16) -> TUI {
         let tb = Termbox::init_test(w, h);
         TUI::new_tb(None, tb)
     }
@@ -354,7 +353,7 @@ impl TUI {
     }
 
     /// Returns index of the new tab if a new tab is created.
-    pub(crate) fn new_server_tab(&mut self, serv: &str, alias: Option<String>) -> Option<usize> {
+    pub fn new_server_tab(&mut self, serv: &str, alias: Option<String>) -> Option<usize> {
         match self.find_serv_tab_idx(serv) {
             None => {
                 let tab_idx = self.tabs.len();
@@ -612,7 +611,6 @@ impl TUI {
                     } else {
                         i as usize - 1
                     };
-                    use std::cmp::Ordering;
                     match new_tab_idx.cmp(&self.active_idx) {
                         Ordering::Greater => {
                             for _ in 0..new_tab_idx - self.active_idx {
@@ -668,9 +666,8 @@ impl TUI {
         self.resize_();
     }
 
-    #[cfg(test)]
     /// Set terminal size. Useful when testing resizing.
-    pub(crate) fn set_size(&mut self, w: u16, h: u16) {
+    pub fn set_size(&mut self, w: u16, h: u16) {
         self.tb.set_buffer_size(w, h);
 
         self.width = i32::from(w);
@@ -687,6 +684,7 @@ impl TUI {
             } else {
                 0
             };
+
         for tab in &mut self.tabs {
             tab.widget
                 .resize(self.width, self.height - 1 - statusline_height);
@@ -827,7 +825,7 @@ impl TUI {
         (i, j)
     }
 
-    pub(crate) fn draw(&mut self) {
+    pub fn draw(&mut self) {
         self.tb.clear();
 
         if self.height < 2 {
@@ -1234,7 +1232,7 @@ impl TUI {
 
     /// A message without any explicit sender info. Useful for e.g. in server
     /// and debug log tabs. Timestamped and logged.
-    pub(crate) fn add_msg(&mut self, msg: &str, ts: Tm, target: &MsgTarget) {
+    pub fn add_msg(&mut self, msg: &str, ts: Tm, target: &MsgTarget) {
         self.apply_to_target(target, &|tab: &mut Tab, _| {
             tab.widget.add_msg(msg, Timestamp::from(ts));
         });


### PR DESCRIPTION
This removes nightly-only bench setup.

I had to make some TUI modules and methods public to be able to use in benchmarks.