### PR TITLE
Improve prefix parsing and ambiguous prefix handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   syntax) are now printed to `tiny_debug_logs.txt` file in the log directory. If
   logging is disabled then the file is created at tiny's working directory.
   (#238)
+- Handling of IRC messages with ambiguous prefix (when it's unclear whether the
+  sender is a server or nick) improved. tiny should now work better with some
+  bouncers such as soju. (#249)
 
 # 2020/06/28: 0.6.0
 

--- a/libtiny_wire/src/lib.rs
+++ b/libtiny_wire/src/lib.rs
@@ -750,5 +750,23 @@ mod tests {
                 user: "".to_string()
             }
         );
+        assert_eq!(
+            parse_pfx("fe-00106.xyz.net"),
+            Server("fe-00106.xyz.net".to_string())
+        );
+        assert_eq!(
+            parse_pfx("osa1!osa1@x.y.im"),
+            User {
+                nick: "osa1".to_string(),
+                user: "osa1@x.y.im".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_pfx("IRC!IRC@fe-00106.xyz.net"),
+            User {
+                nick: "IRC".to_string(),
+                user: "IRC@fe-00106.xyz.net".to_string()
+            }
+        );
     }
 }

--- a/tiny/src/conn.rs
+++ b/tiny/src/conn.rs
@@ -145,7 +145,7 @@ fn handle_irc_msg(ui: &dyn UI, client: &Client, msg: wire::Msg) {
 
             // Sender to be shown in the UI
             let sender = match pfx {
-                Server(_) => serv,
+                Server(ref serv) => serv,
                 User { ref nick, .. } | Ambiguous(ref nick) => nick,
             };
 

--- a/tiny/src/conn.rs
+++ b/tiny/src/conn.rs
@@ -144,19 +144,19 @@ fn handle_irc_msg(ui: &dyn UI, client: &Client, msg: wire::Msg) {
             };
 
             // Sender to be shown in the UI
-            let origin = match pfx {
+            let sender = match pfx {
                 Server(_) => serv,
                 User { ref nick, .. } | Ambiguous(ref nick) => nick,
             };
 
             if ctcp == Some(wire::CTCP::Version) {
-                let msg_target = if ui.user_tab_exists(serv, origin) {
-                    MsgTarget::User { serv, nick: origin }
+                let msg_target = if ui.user_tab_exists(serv, sender) {
+                    MsgTarget::User { serv, nick: sender }
                 } else {
                     MsgTarget::Server { serv }
                 };
                 ui.add_client_msg(
-                    &format!("Received version request from {}", origin),
+                    &format!("Received version request from {}", sender),
                     &msg_target,
                 );
                 return;
@@ -169,17 +169,17 @@ fn handle_irc_msg(ui: &dyn UI, client: &Client, msg: wire::Msg) {
                     let ui_msg_target = MsgTarget::Chan { serv, chan: &chan };
                     // highlight the message if it mentions us
                     if msg.find(&client.get_nick()).is_some() {
-                        ui.add_privmsg(origin, &msg, ts, &ui_msg_target, true, is_action);
+                        ui.add_privmsg(sender, &msg, ts, &ui_msg_target, true, is_action);
                         ui.set_tab_style(TabStyle::Highlight, &ui_msg_target);
                         let mentions_target = MsgTarget::Server { serv: "mentions" };
                         ui.add_msg(
-                            &format!("{} in {}:{}: {}", origin, serv, chan, msg),
+                            &format!("{} in {}:{}: {}", sender, serv, chan, msg),
                             ts,
                             &mentions_target,
                         );
                         ui.set_tab_style(TabStyle::Highlight, &mentions_target);
                     } else {
-                        ui.add_privmsg(origin, &msg, ts, &ui_msg_target, false, is_action);
+                        ui.add_privmsg(sender, &msg, ts, &ui_msg_target, false, is_action);
                         ui.set_tab_style(TabStyle::NewMsg, &ui_msg_target);
                     }
                 }
@@ -202,7 +202,7 @@ fn handle_irc_msg(ui: &dyn UI, client: &Client, msg: wire::Msg) {
                             }
                         }
                     };
-                    ui.add_privmsg(origin, &msg, ts, &msg_target, false, is_action);
+                    ui.add_privmsg(sender, &msg, ts, &msg_target, false, is_action);
                     if target == client.get_nick() {
                         ui.set_tab_style(TabStyle::Highlight, &msg_target);
                     } else {


### PR DESCRIPTION
Previously when we see an ambiguous prefix (e.g. "localhost") we'd assume
server. We now have a prefix variant `Ambiguous` for such cases and resolving
the ambiguity is left to the caller.

When there's an ambiguity we try to do the reasonable thing depending on the
type of the message:

- When the message is a numeric reply we assume server.
- In all other cases (e.g. in JOIN/PART/QUIT/PRIVMSG) we assume nick.

Other changes:

- Removed wildcard patterns to make the code future-proof.
- Refactored some logging and comments.

Fixes #247

