### PR TITLE
term_input: Enable non-blocking mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ name = "term_input"
 version = "0.2.0"
 dependencies = [
  "libc",
+ "log",
  "mio",
  "nix",
  "term_input_macros",

--- a/term_input/Cargo.toml
+++ b/term_input/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2"
+log = "0.4"
 mio = "0.7"
 nix = "0.19"
 term_input_macros = { path = "../term_input_macros" }

--- a/termbox/src/lib.rs
+++ b/termbox/src/lib.rs
@@ -126,7 +126,9 @@ impl Termbox {
         new_term.c_cflag &= !(libc::CSIZE | libc::PARENB);
         new_term.c_cflag |= libc::CS8;
         // Enabled non-canonical mode above. Also set VMIN and VTIME = 0 so that `read(stdin)`
-        // won't block.
+        // won't block. References:
+        // - https://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html
+        // - https://www.gnu.org/software/libc/manual/html_node/Noncanonical-Input.html
         new_term.c_cc[libc::VMIN] = 0;
         new_term.c_cc[libc::VTIME] = 0;
 


### PR DESCRIPTION
Normally term_input is used with non-canonical input with VMIN=0 and
VTIME=0. On Linux in this mode stdin does not block (returns 0 when it's
not ready for reading, see [1] and [2]). However on WSL it doesn't work
that way and we have to set stdin to non-blocking mode to be able to do
`read(stdin)` without blocking.

We now set stdin to non-blocking mode when creating an `Input` and
restore the old flags when dropping it.

Fixes #269

[1]: https://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html
[2]: https://www.gnu.org/software/libc/manual/html_node/Noncanonical-Input.html