### PR TITLE
Lock file update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "tiny"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "dirs 3.0.1",


### PR DESCRIPTION
`Cargo.lock` must have not been committed since the `tiny` version was not
updated for the new release.