### PR TITLE
First iteration for logging configuration

### DIFF
--- a/libtiny_logger/src/lib.rs
+++ b/libtiny_logger/src/lib.rs
@@ -10,6 +10,9 @@ use time::Tm;
 
 use libtiny_common::{ChanName, ChanNameRef, MsgTarget};
 
+#[cfg(test)]
+mod tests;
+
 #[macro_use]
 extern crate log;
 

--- a/libtiny_logger/src/tests.rs
+++ b/libtiny_logger/src/tests.rs
@@ -1,0 +1,172 @@
+use fs::remove_dir_all;
+
+use super::*;
+
+static TEST_LOG_DIR_PREFIX: &str = "./test_logs_";
+fn init(test_name: &str) -> Logger {
+    let test_path = PathBuf::from(TEST_LOG_DIR_PREFIX.to_owned() + test_name);
+    Logger::new(test_path, Box::new(|_| {})).unwrap()
+}
+
+fn cleanup(test_name: &str) {
+    remove_dir_all(TEST_LOG_DIR_PREFIX.to_owned() + test_name).unwrap();
+}
+
+fn server_file_exists(logger: &LoggerInner, server_name: &str) -> bool {
+    logger.servers.get(server_name).unwrap().fd.is_some()
+}
+
+fn chan_file_exists(logger: &LoggerInner, server_name: &str, chan_name: &ChanNameRef) -> bool {
+    logger
+        .servers
+        .get(server_name)
+        .unwrap()
+        .chans
+        .get(chan_name)
+        .unwrap()
+        .file
+        .is_some()
+}
+
+fn user_file_exists(logger: &LoggerInner, server_name: &str, user_name: &str) -> bool {
+    logger
+        .servers
+        .get(server_name)
+        .unwrap()
+        .users
+        .get(user_name)
+        .unwrap()
+        .file
+        .is_some()
+}
+
+#[test]
+fn with_dir_only() {
+    let logger = init("with_dir_only");
+    let server_name = "server";
+    let chan_name = ChanNameRef::new("#test");
+    let user_name = "irc_user";
+
+    logger.new_server_tab(server_name);
+    logger.new_chan_tab(server_name, chan_name);
+    logger.add_msg(
+        "hi",
+        time::now(),
+        &MsgTarget::User {
+            serv: server_name,
+            nick: user_name,
+        },
+    );
+
+    let logger = logger.inner.borrow();
+    let server_file = server_file_exists(&logger, server_name);
+    let chan_file = chan_file_exists(&logger, server_name, chan_name);
+    let user_file = user_file_exists(&logger, server_name, user_name);
+
+    assert!(server_file);
+    assert!(chan_file);
+    assert!(user_file);
+
+    cleanup("with_dir_only");
+}
+
+#[test]
+fn with_server_disabled_chans_enabled() {
+    let logger = init("with_server_disabled_chans_enabled");
+    let server_name = "server";
+    let chan_name = ChanNameRef::new("#test");
+    // disable channels only
+    logger.add_server_config(server_name, Some(false), Some(true), None);
+    logger.new_server_tab(server_name);
+    logger.new_chan_tab(server_name, chan_name);
+
+    let logger = logger.inner.borrow();
+    let server_file = server_file_exists(&logger, server_name);
+    let chan_file = chan_file_exists(&logger, server_name, chan_name);
+
+    assert!(!server_file);
+    assert!(chan_file);
+
+    cleanup("with_server_disabled_chans_enabled")
+}
+
+#[test]
+fn with_specific_chan_enabled_all_disabled() {
+    let logger = init("with_specific_chan_enabled_all_disabled");
+    let server_name = "server";
+    let chan_name = ChanNameRef::new("#test");
+    let chan_name2 = ChanNameRef::new("#spam");
+    // defaults
+    logger.add_server_config(server_name, Some(false), Some(false), Some(false));
+    // enabled chan
+    logger.add_chan_config(server_name, chan_name.display(), Some(true));
+    // disabled by default
+    logger.add_chan_config(server_name, chan_name2.display(), None);
+
+    logger.new_server_tab(server_name);
+    logger.new_chan_tab(server_name, chan_name);
+
+    let logger = logger.inner.borrow();
+
+    let server_file = server_file_exists(&logger, server_name);
+    let chan_file = chan_file_exists(&logger, server_name, chan_name);
+    let spam_chan_file = chan_file_exists(&logger, server_name, chan_name2);
+
+    assert!(!server_file);
+    assert!(chan_file);
+    assert!(!spam_chan_file);
+
+    cleanup("with_specific_chan_enabled_all_disabled")
+}
+
+#[test]
+fn with_specific_chan_disabled() {
+    let logger = init("with_specific_chan_disabled");
+    let server_name = "server";
+    let chan_name = ChanNameRef::new("#test");
+    // defaults
+    logger.add_server_config(server_name, None, None, None);
+    // disable chan
+    logger.add_chan_config(server_name, chan_name.display(), Some(false));
+    logger.new_server_tab(server_name);
+    logger.new_chan_tab(server_name, chan_name);
+
+    let logger = logger.inner.borrow();
+
+    let server_file = server_file_exists(&logger, server_name);
+    let chan_file = chan_file_exists(&logger, server_name, chan_name);
+
+    assert!(server_file);
+    assert!(!chan_file);
+
+    cleanup("with_specific_chan_disabled")
+}
+
+#[test]
+fn with_user_tabs_disabled() {
+    let logger = init("with_user_tabs_disabled");
+    let server_name = "server";
+    let user_name = "irc_user";
+    // disable user tabs
+    logger.add_server_config(server_name, None, None, Some(false));
+
+    logger.new_server_tab(server_name);
+    logger.add_msg(
+        "hi",
+        time::now(),
+        &MsgTarget::User {
+            serv: "server",
+            nick: user_name,
+        },
+    );
+
+    let logger = logger.inner.borrow();
+
+    let server_file = server_file_exists(&logger, server_name);
+    let user_file = user_file_exists(&logger, server_name, user_name);
+
+    assert!(server_file);
+    assert!(!user_file);
+
+    cleanup("with_user_tabs_disabled")
+}

--- a/tiny/config.yml
+++ b/tiny/config.yml
@@ -11,7 +11,8 @@ servers:
 
       # Channels to automatically join
       join:
-          - '#tiny'
+          - name: "#tiny"
+            logs_enabled: true
 
       # Three authentication methods: pass, sasl, and nickserv_ident
       # These are optional and you probably only need one of these, delete
@@ -29,6 +30,15 @@ servers:
       # (useful when `pass` or `sasl` fields above are not used)
       # nickserv_ident: 'hunter2'
 
+      # Optional logging configuration
+      #
+      # Log file for the server
+      # logs_enabled: false
+      # Default setting for channels
+      # chan_logs_enabled: true
+      # Default setting for user messages
+      # user_logs_enabled: true
+
 # Defaults used when connecting to servers via the /connect command
 defaults:
     nicks: [tiny_user]
@@ -37,7 +47,7 @@ defaults:
     tls: false
 
 # Where to put log files
-log_dir: '{}'
+log_dir: "{}"
 
 # (Optional) Limits the maximum number of messages stored for each UI tab. Defaults to unlimited.
 # scrollback: 512
@@ -56,7 +66,7 @@ log_dir: '{}'
 # Attributes can be combined (e.g [bold, underline]), and valid values are bold
 # and underline.
 colors:
-    nick: [ 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14 ]
+    nick: [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14]
 
     clear:
         fg: default

--- a/tiny/config.yml
+++ b/tiny/config.yml
@@ -48,6 +48,8 @@ defaults:
 
 # Where to put log files
 log_dir: "{}"
+# (Optional) global logging setting (defaults to true)
+# logs_enabled: true
 
 # (Optional) Limits the maximum number of messages stored for each UI tab. Defaults to unlimited.
 # scrollback: 512

--- a/tiny/src/config.rs
+++ b/tiny/src/config.rs
@@ -75,6 +75,7 @@ pub(crate) struct Config {
     pub(crate) servers: Vec<Server>,
     pub(crate) defaults: Defaults,
     pub(crate) log_dir: Option<PathBuf>,
+    pub(crate) logs_enabled: Option<bool>,
 }
 
 /// Returns error descriptions.

--- a/tiny/src/config.rs
+++ b/tiny/src/config.rs
@@ -39,7 +39,7 @@ pub(crate) struct Server {
 
     /// Channels to automatically join.
     #[serde(default)]
-    pub(crate) join: Vec<String>,
+    pub(crate) join: Vec<Chan>,
 
     /// NickServ identification password. Used on connecting to the server and nick change.
     pub(crate) nickserv_ident: Option<String>,
@@ -47,6 +47,16 @@ pub(crate) struct Server {
     /// Authenication method
     #[serde(rename = "sasl")]
     pub(crate) sasl_auth: Option<SASLAuth>,
+
+    pub(crate) logs_enabled: Option<bool>,
+    pub(crate) chan_logs_enabled: Option<bool>,
+    pub(crate) user_logs_enabled: Option<bool>,
+}
+
+#[derive(Clone, Deserialize)]
+pub(crate) struct Chan {
+    pub(crate) name: String,
+    pub(crate) logs_enabled: Option<bool>,
 }
 
 /// Similar to `Server`, but used when connecting via the `/connect` command.
@@ -174,7 +184,7 @@ mod tests {
                 panic!();
             }
             Ok(Config { servers, .. }) => {
-                assert_eq!(servers[0].join, vec!["#tiny".to_owned()]);
+                assert_eq!(servers[0].join[0].name, "#tiny".to_string());
                 assert_eq!(servers[0].tls, true);
             }
         }

--- a/tiny/src/main.rs
+++ b/tiny/src/main.rs
@@ -55,13 +55,14 @@ fn main() {
                     mut servers,
                     defaults,
                     log_dir,
+                    logs_enabled,
                 } = config;
 
                 if !server_args.is_empty() {
                     // Connect only to servers that match at least one of the given patterns
                     servers.retain(|s| server_args.iter().any(|arg| s.addr.contains(arg)))
                 }
-                run(servers, defaults, config_path, log_dir)
+                run(servers, defaults, config_path, log_dir, logs_enabled)
             }
         }
     }
@@ -74,6 +75,7 @@ fn run(
     defaults: config::Defaults,
     config_path: PathBuf,
     log_dir: Option<PathBuf>,
+    logs_enabled: Option<bool>,
 ) {
     let debug_log_file = match log_dir.as_ref() {
         Some(log_dir) => {
@@ -122,7 +124,9 @@ fn run(
                 Ok(logger) => {
                     // set logger configs
                     for server in &servers {
-                        let logs_enabled = Some(server.logs_enabled.unwrap_or(true));
+                        // ultimately default to true if no global logging setting was set
+                        let logs_enabled =
+                            Some(server.logs_enabled.unwrap_or(logs_enabled.unwrap_or(true)));
                         logger.add_server_config(
                             &server.addr,
                             logs_enabled,

--- a/tiny/src/ui.rs
+++ b/tiny/src/ui.rs
@@ -36,7 +36,7 @@ macro_rules! delegate_ui {
 #[derive(Clone)]
 pub(crate) struct UI {
     ui: TUI,
-    logger: Option<Logger>,
+    pub(crate) logger: Option<Logger>,
 }
 
 impl UI {


### PR DESCRIPTION
The code is a bit rough right now, just wanted to get something done for a first draft.

Things to review/discuss:
- Default logging setting -- right now it defaults to true when `log_dir` is configured. I think this makes sense.
- Command args for `/join` and `/connect`(not connected yet) --  do we need the ability to set server logging, chan logging and user logging? See line 179 of `cmd.rs`
- Do we need a new command for turning logs on/off? i.e `/logs on` | `/logs off`

Closes #217 