### PR TITLE
Aligned UI

### DIFF
--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -15,6 +15,7 @@ pub(crate) struct Config {
     pub(crate) colors: Colors,
     #[serde(default = "usize::max_value")]
     pub(crate) scrollback: usize,
+    pub(crate) ui_style: Option<UiStyle>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,6 +25,13 @@ pub struct Style {
 
     /// Termbox bg.
     pub bg: u16,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UiStyle {
+    Compact,
+    Aligned { max_nick_length: usize },
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/libtiny_tui/src/input_area/input_line.rs
+++ b/crates/libtiny_tui/src/input_area/input_line.rs
@@ -17,7 +17,7 @@ impl InputLine {
     pub(crate) fn new() -> InputLine {
         InputLine {
             buffer: Vec::with_capacity(512),
-            line_data: LineDataCache::new(true),
+            line_data: LineDataCache::input_line(0, 0),
         }
     }
 
@@ -25,7 +25,7 @@ impl InputLine {
     pub(crate) fn from_buffer(buffer: Vec<char>) -> InputLine {
         InputLine {
             buffer,
-            line_data: LineDataCache::new(true),
+            line_data: LineDataCache::input_line(0, 0),
         }
     }
 
@@ -84,8 +84,8 @@ impl InputLine {
     /// Calculate hedight of the widget, taking nickname length into account. Only needed when
     /// buffer is wider than width and scrolling is off.
     pub(crate) fn calculate_height(&mut self, width: i32, nick_length: usize) -> usize {
-        if self.line_data.is_dirty() || self.line_data.needs_resize(width, nick_length) {
-            self.line_data.reset(width, nick_length);
+        if self.line_data.is_dirty() || self.line_data.needs_resize(width, nick_length, None) {
+            self.line_data = LineDataCache::input_line(width, nick_length);
             self.line_data
                 .calculate_height(&mut self.buffer.iter().copied(), 0);
         }

--- a/crates/libtiny_tui/src/line_split.rs
+++ b/crates/libtiny_tui/src/line_split.rs
@@ -15,6 +15,7 @@ pub(crate) struct LineDataCache {
     /// The length of the current line that is being added to.
     /// Used to determine when to wrap to the next line in calculate_height()
     current_line_length: i32,
+    /// The type of line we're trying to calculate height for
     line_type: LineType,
 }
 
@@ -28,6 +29,7 @@ pub(crate) enum LineType {
         /// The offset of timestamp + nick on multiline messages
         msg_padding: usize,
     },
+    /// A regular line
     Msg,
 }
 
@@ -118,6 +120,7 @@ impl LineDataCache {
         }
     }
 
+    /// Returns the width of lines that are not the first line
     fn multi_line_width(&self) -> i32 {
         match self.line_type {
             // expand to full width

--- a/crates/libtiny_tui/src/line_split.rs
+++ b/crates/libtiny_tui/src/line_split.rs
@@ -1,80 +1,130 @@
 /// Cache that stores the state of a line's height calculation.
 /// `line_count` is used as the dirty bit to invalidate the cache.
 #[derive(Clone, Debug)]
-pub struct LineDataCache {
+pub(crate) struct LineDataCache {
     /// Indices to split on when we draw, not always whitespaces
     split_indices: Vec<i32>,
     /// The total number of lines (height) that will be rendered
     line_count: Option<i32>,
     /// The current width of InputArea. Used in determining if we need to invalidate due to resize.
     width: i32,
-    /// The current width of the InputLine (may be shorter due to nickname)
+    /// The width of the current line (full width minus nick_length or msg padding)
     line_width: i32,
-    /// Current nickname length. Used in determining if we need to invalidate due to resize.
-    nick_length: usize,
     /// The index into InputLine::buffer of the last whitespace that we saw in calculate_height()
     last_whitespace_idx: Option<i32>,
-    /// True if the last character was a whitespace character
-    prev_char_is_whitespace: bool,
     /// The length of the current line that is being added to.
     /// Used to determine when to wrap to the next line in calculate_height()
     current_line_length: i32,
-    /// If the line of text has a cursor
-    has_cursor: bool,
+    line_type: LineType,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum LineType {
+    Input {
+        /// Current nickname length. Used in determining if we need to invalidate due to resize.
+        nick_length: usize,
+    },
+    AlignedMsg {
+        /// The offset of timestamp + nick on multiline messages
+        msg_padding: usize,
+    },
+    Msg,
+}
+
+impl LineType {
+    pub(crate) fn msg_padding(&self) -> Option<usize> {
+        if let LineType::AlignedMsg { msg_padding } = self {
+            Some(*msg_padding)
+        } else {
+            None
+        }
+    }
 }
 
 impl LineDataCache {
-    pub fn new(has_cursor: bool) -> LineDataCache {
+    pub(crate) fn input_line(width: i32, nick_length: usize) -> LineDataCache {
         LineDataCache {
             split_indices: Vec::new(),
             line_count: None,
-            width: 0,
-            line_width: 0,
-            nick_length: 0,
+            width,
+            line_width: width - nick_length as i32,
             last_whitespace_idx: None,
-            prev_char_is_whitespace: false,
             current_line_length: 0,
-            has_cursor,
+            line_type: LineType::Input { nick_length },
         }
+    }
+
+    pub(crate) fn msg_line(width: i32, msg_padding: Option<usize>) -> LineDataCache {
+        let line_type = if let Some(msg_padding) = msg_padding {
+            LineType::AlignedMsg { msg_padding }
+        } else {
+            LineType::Msg
+        };
+        LineDataCache {
+            split_indices: Vec::new(),
+            line_count: None,
+            width,
+            line_width: width,
+            last_whitespace_idx: None,
+            current_line_length: 0,
+            line_type,
+        }
+    }
+
+    pub(crate) fn line_type(&self) -> LineType {
+        self.line_type
+    }
+
+    pub(crate) fn set_line_type(&mut self, line_type: LineType) {
+        self.line_type = line_type
     }
 
     /// Performs a check to see if the width or nickname length changed
     /// which would require an invalidation of the cache and recalculation of
     /// the line height.
-    pub fn needs_resize(&self, width: i32, nick_length: usize) -> bool {
-        self.width != width || self.nick_length != nick_length
+    pub(crate) fn needs_resize(&self, width: i32, nick_len: usize, msg_pad: Option<usize>) -> bool {
+        // TODO so ugly
+        self.width != width
+            || match (self.line_type, msg_pad) {
+                (LineType::Input { nick_length }, ..) => nick_len != nick_length,
+                (LineType::AlignedMsg { msg_padding }, Some(pad)) => pad != msg_padding,
+                _ => false,
+            }
     }
 
     /// Sets `line_count` to `None`, which invalidates the cache.
-    pub fn set_dirty(&mut self) {
+    pub(crate) fn set_dirty(&mut self) {
         self.line_count = None;
     }
 
     /// Checks if the cache is invalidated by seeing if
     /// `line_count` is `None`.
-    pub fn is_dirty(&self) -> bool {
+    pub(crate) fn is_dirty(&self) -> bool {
         self.line_count.is_none()
     }
 
-    /// Resets the cache to a default state that requires
-    /// a height calculation.
-    pub fn reset(&mut self, width: i32, nick_length: usize) {
-        self.split_indices.clear();
-        self.line_count = None;
-        self.width = width;
-        self.nick_length = nick_length;
-        self.line_width = width - nick_length as i32;
-        self.last_whitespace_idx = None;
-        self.prev_char_is_whitespace = false;
-        self.current_line_length = 0;
-    }
-
-    pub fn get_line_count(&self) -> Option<usize> {
+    pub(crate) fn get_line_count(&self) -> Option<usize> {
         self.line_count.map(|c| c as usize)
     }
 
-    pub fn get_splits(&self) -> &[i32] {
+    pub(crate) fn get_splits(&self) -> &[i32] {
         &self.split_indices
+    }
+
+    pub(crate) fn new_line_offset(&self) -> i32 {
+        match self.line_type {
+            LineType::Input { .. } | LineType::Msg => 0,
+            LineType::AlignedMsg { msg_padding } => msg_padding as i32,
+        }
+    }
+
+    fn multi_line_width(&self) -> i32 {
+        match self.line_type {
+            // expand to full width
+            LineType::Input { .. } | LineType::Msg => self.width,
+            // consecutive lines can apply an offset
+            LineType::AlignedMsg { msg_padding } => self.width - msg_padding as i32,
+        }
     }
 
     /// Function that calculates the height of the line.
@@ -86,15 +136,18 @@ impl LineDataCache {
     /// will be needed to render the text with word wrapping.
     /// If an offset is provided, it will continue the calculation
     /// from the saved state and save the new line count in `line_count`.
-    pub fn calculate_height<I: Iterator<Item = char>>(&mut self, buffer: I, offset: usize) {
+    pub(crate) fn calculate_height<I: Iterator<Item = char>>(&mut self, buffer: I, offset: usize) {
         let mut temp_count = 1;
         if let Some(line_count) = self.line_count {
             temp_count = line_count;
             // If we made space for the cursor, subtract it.
-            if self.has_cursor && self.current_line_length == self.line_width {
-                temp_count -= 1;
+            if let LineType::Input { .. } = self.line_type {
+                if self.current_line_length == self.line_width {
+                    temp_count -= 1;
+                }
             }
         }
+
         for (c, current_idx) in buffer.skip(offset).zip(offset..) {
             let current_idx = current_idx as i32;
             self.current_line_length += 1;
@@ -108,24 +161,35 @@ impl LineDataCache {
                     self.current_line_length = 1;
                     // nick is shown on the first line, set width to full width in the consecutive
                     // lines
-                    self.line_width = self.width;
+                    self.line_width = self.multi_line_width();
+
                     // store index for drawing
                     self.split_indices.push(current_idx);
                 }
                 // store whitespace for splitting
                 self.last_whitespace_idx = Some(current_idx);
-                self.prev_char_is_whitespace = true;
             } else {
-                // Splitting
+                // Splitting on non-whitespace
                 if self.current_line_length > self.line_width {
+                    // set width to full width
+                    self.line_width = self.multi_line_width();
                     // if the previous character was a whitespace, then we have a clean split
-                    if !self.prev_char_is_whitespace && self.last_whitespace_idx.is_some() {
-                        // move back to the last whitespace and get the length of the input that
-                        // will be on the next line
-                        self.current_line_length = current_idx - self.last_whitespace_idx.unwrap();
-                        // store index for drawing
-                        self.split_indices
-                            .push(self.last_whitespace_idx.unwrap() + 1);
+                    if let Some(last_whitespace_idx) = self.last_whitespace_idx {
+                        // if the split is larger than the width we have,
+                        // we just want to do an unclean split (mainly only for links or if someone spams a super long line)
+                        if current_idx - last_whitespace_idx > self.line_width {
+                            // unclean split on non-whitespace
+                            self.current_line_length = 1;
+                            // store index for drawing
+                            self.split_indices.push(current_idx);
+                        } else {
+                            // move back to the last whitespace and get the length of the input that
+                            // will be on the next line
+                            self.current_line_length = current_idx - last_whitespace_idx;
+
+                            // store index for drawing
+                            self.split_indices.push(last_whitespace_idx + 1);
+                        }
                     } else {
                         // unclean split on non-whitespace
                         self.current_line_length = 1;
@@ -136,16 +200,15 @@ impl LineDataCache {
                     self.last_whitespace_idx = None;
                     // moved to next line
                     temp_count += 1;
-                    // set width to full width
-                    self.line_width = self.width;
                 }
-                self.prev_char_is_whitespace = false;
             }
         }
 
         // Last line length is `line_width`, make room for cursor
-        if self.has_cursor && self.current_line_length == self.line_width {
-            temp_count += 1;
+        if let LineType::Input { .. } = self.line_type {
+            if self.current_line_length == self.line_width {
+                temp_count += 1;
+            }
         }
         self.line_count = Some(temp_count);
     }

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -315,7 +315,12 @@ impl MessagingUI {
         let layout = self.msg_area.layout();
         let format_nick = |s: &str| -> String {
             if let Layout::Aligned { max_nick_len, .. } = layout {
-                format!("{:>padding$.padding$}", s, padding = max_nick_len)
+                let mut aligned = format!("{:>padding$}", s, padding = max_nick_len);
+                if aligned.len() > max_nick_len {
+                    aligned.truncate(max_nick_len - 1);
+                    aligned.push('…');
+                }
+                aligned
             } else {
                 s.to_string()
             }
@@ -457,6 +462,18 @@ impl MessagingUI {
             }
             _ => {
                 self.add_timestamp(ts);
+                if let Layout::Aligned {
+                    max_nick_len,
+                    msg_nick_sep_len,
+                    ..
+                } = self.msg_area.layout()
+                {
+                    self.msg_area.add_text(
+                        &format!("{:^max$}", "", max = max_nick_len + msg_nick_sep_len),
+                        SegStyle::UserMsg,
+                    )
+                }
+                self.msg_area.set_current_line_alignment();
                 let line_idx = self.msg_area.flush_line();
                 self.last_activity_line = Some(ActivityLine { ts, line_idx });
                 line_idx

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -58,7 +58,7 @@ impl Timestamp {
     /// Inserts a blank space that is the size of a timestamp
     fn blank(msg_area: &mut MsgArea) {
         msg_area.add_text(
-            &format!("{:^width$}", ' ', width = Timestamp::WIDTH),
+            &format!("{:^width$}", "", width = Timestamp::WIDTH),
             SegStyle::Timestamp,
         );
     }
@@ -248,10 +248,9 @@ fn get_input_field_max_height(window_height: i32) -> i32 {
 impl MessagingUI {
     fn add_timestamp(&mut self, ts: Timestamp) {
         if let Some(ts_) = self.last_activity_ts {
-            let alignment = matches!(self.msg_area.layout(), Layout::Aligned { .. }); // for now
             if ts_ != ts {
                 ts.stamp(&mut self.msg_area);
-            } else if alignment {
+            } else if matches!(self.msg_area.layout(), Layout::Aligned { .. }) {
                 Timestamp::blank(&mut self.msg_area)
             }
         } else {
@@ -331,7 +330,7 @@ impl MessagingUI {
             // separator between nick and msg
             self.msg_area.add_text("  ", SegStyle::Faded);
             self.msg_area.add_text(sender, nick_col_style);
-            // a space replacing the :
+            // a space replacing the usual ':'
             self.msg_area.add_text(" ", SegStyle::UserMsg);
         } else {
             self.msg_area.add_text(&format_nick(sender), nick_col_style);

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -315,9 +315,9 @@ impl MessagingUI {
         let layout = self.msg_area.layout();
         let format_nick = |s: &str| -> String {
             if let Layout::Aligned { max_nick_len, .. } = layout {
-                let mut aligned = format!("{:>padding$}", s, padding = max_nick_len);
-                if aligned.len() > max_nick_len {
-                    aligned.truncate(max_nick_len - 1);
+                let mut aligned = format!("{:>padding$.padding$}", s, padding = max_nick_len);
+                if s.len() > max_nick_len {
+                    aligned.pop();
                     aligned.push('…');
                 }
                 aligned

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -112,6 +112,7 @@ impl TUI {
         self.tb.activate()
     }
 
+    #[cfg(test)]
     pub(crate) fn set_layout(&mut self, layout: Layout) {
         self.msg_layout = layout
     }

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -11,7 +11,7 @@ servers:
 
       # Channels to automatically join
       join:
-          - '#tiny'
+          - "#tiny"
 
       # Three authentication methods: pass, sasl, and nickserv_ident
       # These are optional and you probably only need one of these, delete
@@ -37,10 +37,17 @@ defaults:
     tls: false
 
 # Where to put log files
-log_dir: '{}'
+log_dir: "{}"
 
 # (Optional) Limits the maximum number of messages stored for each UI tab. Defaults to unlimited.
 # scrollback: 512
+
+# (Optional) UI Message Layout Style. Defaults to 'compact'
+# ui_style: compact
+# ui_style:
+#   aligned:
+#     # Nicks greater than this value will be truncated
+#     max_nick_length: 12
 
 # Color theme based on 256 colors. Colors can be defined as color indices
 # (0-255) or with their names.
@@ -56,7 +63,7 @@ log_dir: '{}'
 # Attributes can be combined (e.g [bold, underline]), and valid values are bold
 # and underline.
 colors:
-    nick: [ 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14 ]
+    nick: [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14]
 
     clear:
         fg: default


### PR DESCRIPTION
Added Aligned UI, which can be turned on or off, and configured (currently only minimally).

Implementation details:

- The message area now has a `Layout` -- `Compact` (original) and `Aligned`.
- Each `Line` getting constructed  will have a type -- regular and aligned (`Msg` and `Aligned`, within `LineDataCache`). Not all message lines are aligned in the aligned ui (ex. topics)
- Drawing will consider the line type when drawing each line.

Small refactors are included.

Closes #169 and #299
