### PR TITLE
Recalculate scroll value on window resize

### DIFF
--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -48,12 +48,12 @@ impl Layout {
 
 #[derive(Debug, Default)]
 struct Scroll {
-    /// An offset from the last visible line.
-    /// E.g. when this is 0, `self.lines[self.lines.len() - 1]` is drawn at the
-    /// bottom of screen.
+    /// An offset of visible lines from the last visible line of the most recent Line
+    /// E.g. when this is 0, `self.lines.last()` is drawn at the
+    /// bottom of screen. When it is not 0, it is N lines up in the message area.
     scroll: i32,
-    /// Current index of line drawn at the top of the screen
-    /// Used to recalculate `scroll` on resizing of window
+    /// Current index into `self.lines` of the Line drawn at the top of the screen.
+    /// Used to recalculate `scroll` on resizing of window and maintain scrolling in the correct place
     line_idx: usize,
 }
 

--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -76,12 +76,10 @@ impl MsgArea {
     }
 
     pub(crate) fn resize(&mut self, width: i32, height: i32) {
-        eprintln!("before {:?}", self.scroll);
         self.width = width;
         self.height = height;
         self.lines_height = None;
         self.lines_height();
-        eprintln!("after {:?}", self.scroll);
     }
 
     pub(crate) fn layout(&self) -> Layout {

--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -79,7 +79,7 @@ impl MsgArea {
         self.width = width;
         self.height = height;
         self.lines_height = None;
-        self.lines_height();
+        self.total_visible_lines();
     }
 
     pub(crate) fn layout(&self) -> Layout {
@@ -141,7 +141,8 @@ impl MsgArea {
 // Scrolling
 
 impl MsgArea {
-    fn lines_height(&mut self) -> i32 {
+    /// The total number of visible lines if each Line was rendered at the current screen width
+    fn total_visible_lines(&mut self) -> i32 {
         match self.lines_height {
             Some(height) => height,
             None => {
@@ -162,7 +163,7 @@ impl MsgArea {
     }
 
     pub(crate) fn scroll_up(&mut self) {
-        if self.scroll.scroll < max(0, self.lines_height() - self.height) {
+        if self.scroll.scroll < max(0, self.total_visible_lines() - self.height) {
             self.scroll.scroll += 1;
         }
     }
@@ -174,7 +175,7 @@ impl MsgArea {
     }
 
     pub(crate) fn scroll_top(&mut self) {
-        self.scroll.scroll = max(0, self.lines_height() - self.height);
+        self.scroll.scroll = max(0, self.total_visible_lines() - self.height);
     }
 
     pub(crate) fn scroll_bottom(&mut self) {
@@ -288,6 +289,6 @@ mod tests {
         // Will pop out "first" line
         msg_area.flush_line();
         assert_eq!(msg_area.lines.len(), 3);
-        assert_eq!(msg_area.lines_height(), 3);
+        assert_eq!(msg_area.total_visible_lines(), 3);
     }
 }

--- a/crates/libtiny_tui/src/tests/layout.rs
+++ b/crates/libtiny_tui/src/tests/layout.rs
@@ -1,0 +1,70 @@
+use std::panic::Location;
+
+use libtiny_common::{ChanNameRef, MsgTarget};
+
+use crate::msg_area::Layout;
+use crate::test_utils::expect_screen;
+use crate::tui::TUI;
+
+#[test]
+fn test_join_part_overflow() {
+    let mut tui = TUI::new_test(21, 4);
+    let serv = "irc.server_1.org";
+    let chan = ChanNameRef::new("#chan");
+    tui.new_server_tab(serv, None);
+    tui.set_nick(serv, "osa1");
+    tui.new_chan_tab(serv, chan);
+    tui.next_tab();
+    tui.next_tab();
+
+    let target = MsgTarget::Chan { serv, chan };
+    let ts = time::at_utc(time::Timespec::new(0, 0));
+    tui.add_nick("123456", Some(ts), &target);
+    tui.add_nick("abcdef", Some(ts), &target);
+    tui.add_nick("hijklm", Some(ts), &target);
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|00:00 +123456 +abcdef|
+         |+hijklm              |
+         |osa1:                |
+         |< #chan              |";
+
+    expect_screen(screen, &tui.get_front_buffer(), 21, 4, Location::caller());
+}
+
+#[test]
+fn test_alignment_long_string() {
+    let mut tui = TUI::new_test(40, 5);
+    tui.set_layout(Layout::Aligned { max_nick_len: 12 });
+    let serv = "irc.server_1.org";
+    let chan = ChanNameRef::new("#chan");
+    tui.new_server_tab(serv, None);
+    tui.set_nick(serv, "osa1");
+    tui.new_chan_tab(serv, chan);
+    tui.next_tab();
+    tui.next_tab();
+
+    let target = MsgTarget::Chan { serv, chan };
+    let ts = time::at_utc(time::Timespec::new(0, 0));
+    tui.add_privmsg(
+        "osa1",
+        "123456789012345678901234567890",
+        ts,
+        &target,
+        false,
+        false,
+    );
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|                                        |
+         |00:00         osa1: 12345678901234567890|
+         |                    1234567890          |
+         |osa1:                                   |
+         |mentions irc.server_1.org #chan         |";
+
+    expect_screen(screen, &tui.get_front_buffer(), 40, 5, Location::caller());
+}

--- a/crates/libtiny_tui/src/tests/resize.rs
+++ b/crates/libtiny_tui/src/tests/resize.rs
@@ -1,0 +1,267 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::panic::Location;
+
+use libtiny_common::{ChanNameRef, MsgTarget};
+use term_input::Key;
+
+use crate::test_utils::expect_screen;
+use crate::tui::TUI;
+
+#[test]
+fn test_resize_recalc_scroll() {
+    let mut tui = TUI::new_test(15, 5);
+    let serv = "irc.server_1.org";
+    let chan = ChanNameRef::new("#chan");
+    tui.new_server_tab(serv, None);
+    tui.set_nick(serv, "osa1");
+    tui.new_chan_tab(serv, chan);
+    tui.next_tab();
+    tui.next_tab();
+
+    let target = MsgTarget::Chan { serv, chan };
+    let ts = time::at_utc(time::Timespec::new(0, 0));
+    tui.add_privmsg(
+        "osa1",
+        "s 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 e",
+        ts,
+        &target,
+        false,
+        false,
+    );
+
+    tui.draw();
+
+    // at bottom with no scroll
+    #[rustfmt::skip]
+    let screen1 =
+       "|1111 1111 1111 |
+        |1111 1111 1111 |
+        |1111 e         |
+        |               |
+        |< #chan        |";
+
+    expect_screen(screen1, &tui.get_front_buffer(), 15, 5, Location::caller());
+
+    // hit the home key to go to the top of the messages and then resize the screen
+    let home = term_input::Event::Key(Key::Home);
+    tui.handle_input_event(home, &mut None);
+    tui.set_size(16, 7);
+    tui.draw();
+
+    // should be at the top of message after resize
+    #[rustfmt::skip]
+    let screen2 =
+       "|00:00 osa1: s   |
+        |1111 1111 1111  |
+        |1111 1111 1111  |
+        |1111 1111 1111  |
+        |1111 1111 1111  |
+        |                |
+        |< #chan         |";
+
+    expect_screen(screen2, &tui.get_front_buffer(), 16, 7, Location::caller());
+
+    // go back to the bottom
+    let end = term_input::Event::Key(Key::End);
+    tui.handle_input_event(end, &mut None);
+    tui.draw();
+
+    // go back to the bottom
+    #[rustfmt::skip]
+    let screen3 = 
+       "|1111 1111 1111  |
+        |1111 1111 1111  |
+        |1111 1111 1111  |
+        |1111 1111 1111  |
+        |1111 e          |
+        |                |
+        |< #chan         |";
+
+    expect_screen(screen3, &tui.get_front_buffer(), 16, 7, Location::caller());
+}
+
+#[test]
+fn test_resize_scroll_stick_to_top() {
+    let mut tui = TUI::new_test(18, 10);
+    let serv = "irc.server_1.org";
+    let chan = ChanNameRef::new("#chan");
+    tui.new_server_tab(serv, None);
+    tui.set_nick(serv, "osa1");
+    tui.new_chan_tab(serv, chan);
+    tui.next_tab();
+    tui.next_tab();
+
+    let target = MsgTarget::Chan { serv, chan };
+    let ts = time::at_utc(time::Timespec::new(0, 0));
+
+    for i in 0..15 {
+        tui.add_privmsg("osa1", &format!("line{}", i), ts, &target, false, false);
+    }
+
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen1 =
+       "|osa1: line7       |
+        |osa1: line8       |
+        |osa1: line9       |
+        |osa1: line10      |
+        |osa1: line11      |
+        |osa1: line12      |
+        |osa1: line13      |
+        |osa1: line14      |
+        |                  |
+        |< #chan           |";
+
+    expect_screen(screen1, &tui.get_front_buffer(), 18, 10, Location::caller());
+
+    // scroll up two lines, resize to add one extra line and verify that the next line on the bottom shows
+    for _ in 0..2 {
+        tui.handle_input_event(term_input::Event::Key(Key::ShiftUp), &mut None);
+    }
+    tui.draw();
+    tui.set_size(18, 11);
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen2 =
+       "|osa1: line5       |
+        |osa1: line6       |
+        |osa1: line7       |
+        |osa1: line8       |
+        |osa1: line9       |
+        |osa1: line10      |
+        |osa1: line11      |
+        |osa1: line12      |
+        |osa1: line13      |
+        |                  |
+        |< #chan           |";
+    expect_screen(screen2, &tui.get_front_buffer(), 18, 11, Location::caller());
+}
+
+#[test]
+fn test_resize_no_scroll_stay_on_bottom() {
+    let mut tui = TUI::new_test(18, 10);
+    let serv = "irc.server_1.org";
+    let chan = ChanNameRef::new("#chan");
+    tui.new_server_tab(serv, None);
+    tui.set_nick(serv, "osa1");
+    tui.new_chan_tab(serv, chan);
+    tui.next_tab();
+    tui.next_tab();
+
+    let target = MsgTarget::Chan { serv, chan };
+    let ts = time::at_utc(time::Timespec::new(0, 0));
+
+    for i in 0..15 {
+        tui.add_privmsg("osa1", &format!("line{}", i), ts, &target, false, false);
+    }
+
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen1 =
+       "|osa1: line7       |
+        |osa1: line8       |
+        |osa1: line9       |
+        |osa1: line10      |
+        |osa1: line11      |
+        |osa1: line12      |
+        |osa1: line13      |
+        |osa1: line14      |
+        |                  |
+        |< #chan           |";
+
+    expect_screen(screen1, &tui.get_front_buffer(), 18, 10, Location::caller());
+
+    tui.set_size(18, 11);
+    tui.draw();
+
+    // shows one extra line on the top of the screen
+    #[rustfmt::skip]
+    let screen2 =
+       "|osa1: line6       |
+        |osa1: line7       |
+        |osa1: line8       |
+        |osa1: line9       |
+        |osa1: line10      |
+        |osa1: line11      |
+        |osa1: line12      |
+        |osa1: line13      |
+        |osa1: line14      |
+        |                  |
+        |< #chan           |";
+    expect_screen(screen2, &tui.get_front_buffer(), 18, 11, Location::caller());
+
+    // resize back to original screen and verify last line is still on the bottom
+    tui.set_size(18, 10);
+    tui.draw();
+    expect_screen(screen1, &tui.get_front_buffer(), 18, 10, Location::caller());
+
+    tui.add_privmsg("osa1", "line15", ts, &target, false, false);
+    tui.set_size(18, 11);
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen3 =
+       "|osa1: line7       |
+        |osa1: line8       |
+        |osa1: line9       |
+        |osa1: line10      |
+        |osa1: line11      |
+        |osa1: line12      |
+        |osa1: line13      |
+        |osa1: line14      |
+        |osa1: line15      |
+        |                  |
+        |< #chan           |";
+    expect_screen(screen3, &tui.get_front_buffer(), 18, 11, Location::caller());
+}
+
+#[test]
+fn test_resize() {
+    let mut tui = TUI::new_test(80, 50);
+
+    let server = "<server>";
+    tui.new_server_tab(server, None);
+
+    let ts = time::empty_tm();
+    let target = MsgTarget::CurrentTab;
+
+    let f = File::open("test/lipsum.txt").unwrap();
+    let f = BufReader::new(f);
+    for line in f.lines() {
+        let line = line.unwrap();
+        tui.add_msg(&line, ts, &target);
+    }
+
+    let mut w = 80;
+    let mut h = 50;
+
+    for _ in 0..50 {
+        w -= 1;
+        h -= 1;
+        tui.set_size(w, h);
+        tui.draw();
+    }
+
+    for _ in 0..30 {
+        w -= 1;
+        tui.set_size(w, h);
+        tui.draw();
+    }
+
+    for _ in 0..50 {
+        w += 1;
+        h += 1;
+        tui.set_size(w, h);
+        tui.draw();
+    }
+
+    for _ in 0..30 {
+        w += 1;
+        tui.set_size(w, h);
+        tui.draw();
+    }
+}

--- a/crates/libtiny_tui/src/tests/resize.rs
+++ b/crates/libtiny_tui/src/tests/resize.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader};
 use std::panic::Location;
 
 use libtiny_common::{ChanNameRef, MsgTarget};
-use term_input::Key;
+use term_input::{Arrow, Key};
 
 use crate::test_utils::expect_screen;
 use crate::tui::TUI;
@@ -118,7 +118,10 @@ fn test_resize_scroll_stick_to_top() {
 
     // scroll up two lines, resize to add one extra line and verify that the next line on the bottom shows
     for _ in 0..2 {
-        tui.handle_input_event(term_input::Event::Key(Key::ShiftUp), &mut None);
+        tui.handle_input_event(
+            term_input::Event::Key(Key::ShiftArrow(Arrow::Up)),
+            &mut None,
+        );
     }
     tui.draw();
     tui.set_size(18, 11);

--- a/crates/libtiny_tui/src/tests/resize.rs
+++ b/crates/libtiny_tui/src/tests/resize.rs
@@ -219,6 +219,7 @@ fn test_resize_no_scroll_stay_on_bottom() {
     expect_screen(screen3, &tui.get_front_buffer(), 18, 11, Location::caller());
 }
 
+// Simulate resize from 50x50 -> 0x0 -> 50x50
 #[test]
 fn test_resize() {
     let mut tui = TUI::new_test(80, 50);
@@ -236,32 +237,8 @@ fn test_resize() {
         tui.add_msg(&line, ts, &target);
     }
 
-    let mut w = 80;
-    let mut h = 50;
-
-    for _ in 0..50 {
-        w -= 1;
-        h -= 1;
-        tui.set_size(w, h);
-        tui.draw();
-    }
-
-    for _ in 0..30 {
-        w -= 1;
-        tui.set_size(w, h);
-        tui.draw();
-    }
-
-    for _ in 0..50 {
-        w += 1;
-        h += 1;
-        tui.set_size(w, h);
-        tui.draw();
-    }
-
-    for _ in 0..30 {
-        w += 1;
-        tui.set_size(w, h);
+    for i in (0..=50).rev().chain(0..=50) {
+        tui.set_size(i, i);
         tui.draw();
     }
 }


### PR DESCRIPTION
By maintaining the top-most line index, we can recalculate the scroll
offset on screen resize.

Closes #319