### PR TITLE
Message alignment on draw

### DIFF
--- a/crates/libtiny_tui/src/line_split.rs
+++ b/crates/libtiny_tui/src/line_split.rs
@@ -1,3 +1,5 @@
+use crate::msg_area::Layout;
+
 /// Cache that stores the state of a line's height calculation.
 /// `line_count` is used as the dirty bit to invalidate the cache.
 #[derive(Clone, Debug)]
@@ -39,6 +41,17 @@ impl LineType {
             Some(*msg_padding)
         } else {
             None
+        }
+    }
+}
+
+impl From<Layout> for LineType {
+    fn from(layout: Layout) -> Self {
+        match layout {
+            Layout::Compact => LineType::Msg,
+            Layout::Aligned { .. } => LineType::AlignedMsg {
+                msg_padding: layout.msg_padding(),
+            },
         }
     }
 }

--- a/crates/libtiny_tui/src/line_split.rs
+++ b/crates/libtiny_tui/src/line_split.rs
@@ -91,6 +91,7 @@ impl LineDataCache {
     }
 
     pub(crate) fn set_line_type(&mut self, line_type: LineType) {
+        self.set_dirty();
         self.line_type = line_type
     }
 

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -107,6 +107,10 @@ impl MessagingUI {
         self.resize(w, h);
     }
 
+    pub(crate) fn set_layout(&mut self, msg_layout: Layout) {
+        self.msg_area.set_layout(msg_layout)
+    }
+
     pub(crate) fn get_nick(&self) -> Option<String> {
         self.input_field.get_nick()
     }

--- a/crates/libtiny_tui/src/msg_area/line.rs
+++ b/crates/libtiny_tui/src/msg_area/line.rs
@@ -415,6 +415,7 @@ mod tests {
     #[test]
     fn align_test() {
         let mut line = Line::new();
+        line.set_can_align(true);
         line.set_type(LineType::AlignedMsg { msg_padding: 1 });
         /*
         123

--- a/crates/libtiny_tui/src/msg_area/line.rs
+++ b/crates/libtiny_tui/src/msg_area/line.rs
@@ -19,6 +19,7 @@ pub(crate) struct Line {
     current_seg: StyledString,
 
     line_data: LineDataCache,
+    can_align: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -90,11 +91,18 @@ impl Line {
             segments: vec![],
             current_seg: StyledString::default(),
             line_data: LineDataCache::msg_line(0, None),
+            can_align: false,
         }
     }
 
     pub(crate) fn set_type(&mut self, line_type: LineType) {
-        self.line_data.set_line_type(line_type)
+        if !matches!(line_type, LineType::AlignedMsg { .. }) || self.can_align {
+            self.line_data.set_line_type(line_type)
+        }
+    }
+
+    pub(crate) fn set_can_align(&mut self, can_align: bool) {
+        self.can_align = can_align
     }
 
     pub(crate) fn line_type(&self) -> LineType {

--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -73,7 +73,15 @@ impl MsgArea {
 
     /// Used to force a line to be aligned.
     pub(crate) fn set_current_line_alignment(&mut self) {
+        self.line_buf.set_can_align(true);
         self.line_buf.set_type(self.layout.into());
+    }
+
+    pub(crate) fn set_layout(&mut self, layout: Layout) {
+        self.layout = layout;
+        self.lines
+            .iter_mut()
+            .for_each(|line| line.set_type(layout.into()));
     }
 
     pub(crate) fn draw(&mut self, tb: &mut Termbox, colors: &Colors, pos_x: i32, pos_y: i32) {

--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -6,7 +6,6 @@ use termbox_simple::Termbox;
 
 pub(crate) use self::line::{Line, SegStyle};
 use crate::config::Colors;
-use crate::line_split::LineType;
 use crate::messaging::{Timestamp, MSG_NICK_SUFFIX_LEN};
 
 pub(crate) struct MsgArea {
@@ -38,7 +37,7 @@ pub(crate) enum Layout {
 }
 
 impl Layout {
-    fn msg_padding(&self) -> usize {
+    pub(crate) fn msg_padding(&self) -> usize {
         match self {
             Layout::Compact => 0,
             Layout::Aligned { max_nick_len } => {
@@ -72,14 +71,9 @@ impl MsgArea {
         self.lines_height = None;
     }
 
-    pub(crate) fn layout(&self) -> Layout {
-        self.layout
-    }
-
     /// Used to force a line to be aligned.
     pub(crate) fn set_current_line_alignment(&mut self) {
-        let msg_padding = self.layout.msg_padding();
-        self.line_buf.set_type(LineType::AlignedMsg { msg_padding });
+        self.line_buf.set_type(self.layout.into());
     }
 
     pub(crate) fn draw(&mut self, tb: &mut Termbox, colors: &Colors, pos_x: i32, pos_y: i32) {

--- a/crates/libtiny_tui/src/tests/mod.rs
+++ b/crates/libtiny_tui/src/tests/mod.rs
@@ -442,6 +442,19 @@ fn test_alignment_long_string() {
          |mentions irc.server_1.org #chan         |";
 
     expect_screen(screen, &tui.get_front_buffer(), 40, 5, Location::caller());
+
+    tui.add_privmsg("veryverylongnickname", "hi", ts, &target, false, false);
+    tui.draw();
+
+    #[rustfmt::skip]
+    let screen =
+        "|00:00         osa1: 12345678901234567890|
+         |                    1234567890          |
+         |      veryverylon…: hi                  |
+         |osa1:                                   |
+         |mentions irc.server_1.org #chan         |";
+
+    expect_screen(screen, &tui.get_front_buffer(), 40, 5, Location::caller());
 }
 #[test]
 fn test_resize() {

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -288,14 +288,16 @@ impl TUI {
                     self.set_colors(colors);
                     self.scrollback = scrollback.max(1);
                     if let Some(layout) = layout {
-                        match layout {
-                            crate::config::Layout::Compact => self.msg_layout = Layout::Compact,
-                            crate::config::Layout::Aligned => {
-                                self.msg_layout = Layout::Aligned {
-                                    max_nick_len: max_nick_length,
-                                }
-                            }
-                        }
+                        let layout = match layout {
+                            crate::config::Layout::Compact => Layout::Compact,
+                            crate::config::Layout::Aligned => Layout::Aligned {
+                                max_nick_len: max_nick_length,
+                            },
+                        };
+                        self.msg_layout = layout;
+                        self.tabs
+                            .iter_mut()
+                            .for_each(|t| t.widget.set_layout(layout));
                     }
                 }
             }


### PR DESCRIPTION
Instead of applying padding to the actual data in the line buffers, this
applies the correct padding on the fly during line height calculation
and drawing.

~~Not a very good solution since I did this in order to be able to switch
layouts on the fly (#321) but it still doesn't work because we don't always
align every line (i.e topic line, server stuff).~~

Closes #321 