### PR TITLE
Add /quit command

### DIFF
--- a/crates/libtiny_tui/src/exit_dialogue.rs
+++ b/crates/libtiny_tui/src/exit_dialogue.rs
@@ -3,6 +3,7 @@ use termbox_simple::Termbox;
 
 use crate::{config::Colors, widget::WidgetRet};
 
+#[derive(Debug)]
 pub(crate) struct ExitDialogue {
     width: i32,
 }

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -181,7 +181,7 @@ async fn input_handler<S>(
                             let result = tui.borrow_mut().try_handle_cmd(&cmd, &from);
                             match result {
                                 CmdResult::Ok => {}
-                                CmdResult::Skip => {
+                                CmdResult::Continue => {
                                     snd_ev.try_send(Event::Cmd { cmd, source: from }).unwrap()
                                 }
                                 CmdResult::Quit => {

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -22,7 +22,7 @@ mod widget;
 #[cfg(test)]
 mod tests;
 
-use crate::tui::TUIRet;
+use crate::tui::{CmdResult, TUIRet};
 use libtiny_common::{ChanNameRef, Event, MsgTarget, TabStyle};
 
 use futures::select;
@@ -178,9 +178,17 @@ async fn input_handler<S>(
                         if msg[0] == '/' {
                             // Handle TUI commands, send others to downstream
                             let cmd: String = (&msg[1..]).iter().collect();
-                            let handled = tui.borrow_mut().try_handle_cmd(&cmd, &from);
-                            if !handled {
-                                snd_ev.try_send(Event::Cmd { cmd, source: from }).unwrap();
+                            let result = tui.borrow_mut().try_handle_cmd(&cmd, &from);
+                            match result {
+                                CmdResult::Ok => {}
+                                CmdResult::Skip => {
+                                    snd_ev.try_send(Event::Cmd { cmd, source: from }).unwrap()
+                                }
+                                CmdResult::Quit => {
+                                    snd_ev.try_send(Event::Abort).unwrap();
+                                    let _ = snd_abort.try_send(());
+                                    return;
+                                }
                             }
                         } else {
                             snd_ev

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -234,7 +234,7 @@ impl MessagingUI {
         self.input_field.set_cursor(cursor);
     }
 
-    pub(crate) fn toggle_exit_dialogue(&mut self) {
+    fn toggle_exit_dialogue(&mut self) {
         let exit_dialogue = ::std::mem::replace(&mut self.exit_dialogue, None);
         if exit_dialogue.is_none() {
             // We don't show the nick in exit dialogue, so it has the full width

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -94,8 +94,11 @@ pub struct TUI {
 }
 
 pub(crate) enum CmdResult {
+    /// Command executed successfully
     Ok,
-    Skip,
+    /// Pass through from tui to cmd.rs
+    Continue,
+    /// Quit command was executed
     Quit,
 }
 
@@ -272,8 +275,8 @@ impl TUI {
                         &MsgTarget::CurrentTab,
                     );
                 }
-                // false to fall through to print help for cmd.rs commands
-                CmdResult::Skip
+                // Fall through to print help for cmd.rs commands
+                CmdResult::Continue
             }
             Some("quit") => CmdResult::Quit,
             _ => CmdResult::Ok,

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -96,7 +96,7 @@ pub struct TUI {
 pub(crate) enum CmdResult {
     /// Command executed successfully
     Ok,
-    /// Pass through from tui to cmd.rs
+    /// Pass command through to cmd.rs for further handling
     Continue,
     /// Quit command was executed
     Quit,


### PR DESCRIPTION
I often see users in the IRC channel wondering how to quit. They usually figure it out, but I think `/quit` is universal among tui IRC clients