### PR TITLE
Fix broken commands

### DIFF
--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -279,7 +279,7 @@ impl TUI {
                 CmdResult::Continue
             }
             Some("quit") => CmdResult::Quit,
-            _ => CmdResult::Ok,
+            _ => CmdResult::Continue,
         }
     }
 


### PR DESCRIPTION
This fixes a regression that I made when adding the /quit command.
Accidentally stopped processing commands if it was not in the
tui-specific commands, which causes all tiny client commands (cmd.rs) to
be ignored.