### PR TITLE
chore: more friendly error message

### DIFF
--- a/crates/tiny/src/ui.rs
+++ b/crates/tiny/src/ui.rs
@@ -174,10 +174,17 @@ pub(crate) fn send_msg(
     is_action: bool,
 ) {
     if src.serv_name() == "mentions" {
-        ui.add_client_err_msg(
-            "Use `/connect <server>` to connect to a server",
-            &MsgTarget::CurrentTab,
-        );
+        if clients.len() == 0 {
+            ui.add_client_err_msg(
+                "No connected server found, please use `/connect <server>` to connect to a server",
+                &MsgTarget::CurrentTab,
+            );
+        } else {
+            ui.add_client_err_msg(
+                "You are on the mentions tab, please use `/switch <tab name>` to switch to a tab",
+                &MsgTarget::CurrentTab,
+            );
+        }
         return;
     }
 


### PR DESCRIPTION
It confused me for a night when I try to send `/msg NickServ REGISTER passwd email` and the tui always gives me "use `/connect <server>` to connect to a server" error.

But actually I have an connected server. so I got confused.

But if I send `/msg irc.libera.chat NickServ REGISTER passwd email`, it succeed!

After read the code, I found that this is not the right way to send a msg to `NickServ` (thought it works).

The only thing I need to do is switch from the default `mentions` tab to next tab.

and then, `/msg NickServ REGISTER passwd email` works as expected.


