### PR TITLE
Config to set /ignore and /notify

### DIFF
--- a/crates/libtiny_common/src/lib.rs
+++ b/crates/libtiny_common/src/lib.rs
@@ -164,6 +164,25 @@ pub enum MsgTarget<'a> {
     CurrentTab,
 }
 
+impl<'a> MsgTarget<'a> {
+    pub fn serv_name(&self) -> Option<&str> {
+        match self {
+            MsgTarget::Server { serv }
+            | MsgTarget::Chan { serv, .. }
+            | MsgTarget::User { serv, .. }
+            | MsgTarget::AllServTabs { serv } => Some(serv),
+            _ => None,
+        }
+    }
+
+    pub fn chan_name(&self) -> Option<&ChanNameRef> {
+        match self {
+            MsgTarget::Chan { chan, .. } => Some(chan),
+            _ => None,
+        }
+    }
+}
+
 /// Source of a message from the user.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MsgSource {
@@ -183,6 +202,13 @@ impl MsgSource {
             MsgSource::Serv { serv }
             | MsgSource::Chan { serv, .. }
             | MsgSource::User { serv, .. } => serv,
+        }
+    }
+
+    pub fn chan_name(&self) -> Option<&ChanNameRef> {
+        match self {
+            MsgSource::Chan { chan, .. } => Some(chan),
+            _ => None,
         }
     }
 

--- a/crates/libtiny_common/src/lib.rs
+++ b/crates/libtiny_common/src/lib.rs
@@ -175,9 +175,10 @@ impl<'a> MsgTarget<'a> {
         }
     }
 
-    pub fn chan_name(&self) -> Option<&ChanNameRef> {
+    pub fn chan_or_user_name(&self) -> Option<&ChanNameRef> {
         match self {
             MsgTarget::Chan { chan, .. } => Some(chan),
+            MsgTarget::User { nick, .. } => Some(ChanNameRef::new(nick)),
             _ => None,
         }
     }

--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -39,13 +39,11 @@ impl Config {
     /// Gets tab configs for `server`
     /// Prioritizing configs under the server or using defaults
     pub(crate) fn server_tab_configs(&self, server: &str) -> TabConfig {
-        let server_config = self.servers.iter().find_map(|s| {
-            if s.addr == server {
-                Some(&s.configs)
-            } else {
-                None
-            }
-        });
+        let server_config = self
+            .servers
+            .iter()
+            .find(|s| s.addr == server)
+            .map(|s| &s.configs);
         self.defaults.tab_configs.merge(server_config)
     }
 
@@ -56,15 +54,7 @@ impl Config {
             .servers
             .iter()
             .find(|s| s.addr == server)
-            .and_then(|s| {
-                s.join.iter().find_map(|c| {
-                    if &c.name == chan {
-                        Some(c.config)
-                    } else {
-                        None
-                    }
-                })
-            });
+            .and_then(|s| s.join.iter().find(|c| chan == &c.name).map(|c| c.config));
         self.server_tab_configs(server).merge(tab_config.as_ref())
     }
 

--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -220,7 +220,7 @@ pub(crate) enum Layout {
     Aligned,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct Colors {
     pub nick: Vec<u8>,

--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -162,6 +162,16 @@ impl TabConfigs {
         };
         self.0.insert(key, config);
     }
+
+    pub(crate) fn set_by_server(&mut self, serv_name: &str, config: TabConfig) {
+        for c in self
+            .0
+            .iter_mut()
+            .filter(|entry| entry.0.starts_with(serv_name))
+        {
+            *c.1 = config;
+        }
+    }
 }
 
 impl From<&Config> for TabConfigs {
@@ -207,6 +217,12 @@ impl TabConfig {
             ignore: self.ignore.or(config.ignore),
             notify: self.notify.or(config.notify),
         }
+    }
+
+    pub(crate) fn toggle_ignore(&mut self) -> bool {
+        let ignore = self.ignore.get_or_insert(false);
+        *ignore = !&*ignore;
+        *ignore
     }
 }
 

--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -9,7 +9,7 @@ use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;
 
-pub(crate) use termbox_simple::*;
+pub use termbox_simple::*;
 
 use crate::key_map::KeyMap;
 use crate::notifier::Notifier;

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::cognitive_complexity)]
 
-mod config;
+pub mod config;
 mod editor;
 mod exit_dialogue;
 mod input_area;
@@ -23,6 +23,9 @@ mod widget;
 #[cfg(test)]
 mod tests;
 
+pub use notifier::Notifier;
+
+use crate::config::TabConfig;
 use crate::tui::{CmdResult, TUIRet};
 use libtiny_common::{ChanNameRef, Event, MsgSource, MsgTarget, TabStyle};
 use term_input::Input;
@@ -255,6 +258,7 @@ impl TUI {
         chan_name: &ChanNameRef,
     ));
     delegate!(set_tab_style(style: TabStyle, target: &MsgTarget,));
+    delegate!(set_tab_config(config: TabConfig, target: &MsgTarget,));
 
     pub fn user_tab_exists(&self, serv_name: &str, nick: &str) -> bool {
         match self.inner.upgrade() {

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -23,17 +23,13 @@ mod widget;
 #[cfg(test)]
 mod tests;
 
-pub use notifier::Notifier;
-
-use crate::config::TabConfig;
-use crate::tui::{CmdResult, TUIRet};
-use libtiny_common::{ChanNameRef, Event, MsgSource, MsgTarget, TabStyle};
-use term_input::Input;
-
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::{Rc, Weak};
 
+use libtiny_common::{ChanNameRef, Event, MsgSource, MsgTarget, TabStyle};
+pub use notifier::Notifier;
+use term_input::Input;
 use time::Tm;
 use tokio::select;
 use tokio::signal::unix::{signal, SignalKind};
@@ -41,6 +37,9 @@ use tokio::sync::mpsc;
 use tokio::task::spawn_local;
 use tokio_stream::wrappers::{ReceiverStream, SignalStream};
 use tokio_stream::{Stream, StreamExt};
+
+use crate::config::TabConfig;
+use crate::tui::{CmdResult, TUIRet};
 
 #[macro_use]
 extern crate log;
@@ -70,8 +69,9 @@ impl TUI {
         (TUI { inner }, rcv_ev)
     }
 
-    /// Create a test instance that doesn't render to the terminal, just updates the termbox
-    /// buffer. Useful for testing. See also [`get_front_buffer`](TUI::get_front_buffer).
+    /// Create a test instance that doesn't render to the terminal, just updates
+    /// the termbox buffer. Useful for testing. See also
+    /// [`get_front_buffer`](TUI::get_front_buffer).
     pub fn run_test<S>(width: u16, height: u16, input_stream: S) -> (TUI, mpsc::Receiver<Event>)
     where
         S: Stream<Item = std::io::Result<term_input::Event>> + Unpin + 'static,

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -27,9 +27,6 @@ pub(crate) struct MessagingUI {
     width: i32,
     height: i32,
 
-    // Option to disable status messages ( join/part )
-    show_status: bool,
-
     // All nicks in the channel. Need to keep this up-to-date to be able to
     // properly highlight mentions.
     nicks: Trie,
@@ -91,7 +88,6 @@ impl MessagingUI {
     pub(crate) fn new(
         width: i32,
         height: i32,
-        status: bool,
         scrollback: usize,
         msg_layout: Layout,
     ) -> MessagingUI {
@@ -101,7 +97,6 @@ impl MessagingUI {
             exit_dialogue: None,
             width,
             height,
-            show_status: status,
             nicks: Trie::new(),
             last_activity_line: None,
             last_activity_ts: None,
@@ -385,8 +380,8 @@ impl MessagingUI {
         self.nicks.clear();
     }
 
-    pub(crate) fn join(&mut self, nick: &str, ts: Option<Timestamp>) {
-        if self.show_status {
+    pub(crate) fn join(&mut self, nick: &str, ts: Option<Timestamp>, ignore: bool) {
+        if !ignore {
             if let Some(ts) = ts {
                 let line_idx = self.get_activity_line_idx(ts);
                 self.msg_area.modify_line(line_idx, |line| {
@@ -399,10 +394,10 @@ impl MessagingUI {
         self.nicks.insert(nick);
     }
 
-    pub(crate) fn part(&mut self, nick: &str, ts: Option<Timestamp>) {
+    pub(crate) fn part(&mut self, nick: &str, ts: Option<Timestamp>, ignore: bool) {
         self.nicks.remove(nick);
 
-        if self.show_status {
+        if !ignore {
             if let Some(ts) = ts {
                 let line_idx = self.get_activity_line_idx(ts);
                 self.msg_area.modify_line(line_idx, |line| {
@@ -411,21 +406,6 @@ impl MessagingUI {
                 });
             }
         }
-    }
-
-    /// `state` == `None` means toggle
-    /// `state` == `Some(state)` means set it to `state`
-    pub(crate) fn set_or_toggle_status(&mut self, state: Option<bool>) {
-        self.show_status = state.unwrap_or(!self.show_status);
-        if self.show_status {
-            self.add_client_notify_msg("Ignore disabled");
-        } else {
-            self.add_client_notify_msg("Ignore enabled");
-        }
-    }
-
-    pub(crate) fn is_showing_status(&self) -> bool {
-        self.show_status
     }
 
     pub(crate) fn nick(&mut self, old_nick: &str, new_nick: &str, ts: Timestamp) {

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -415,7 +415,7 @@ impl MessagingUI {
 
     /// `state` == `None` means toggle
     /// `state` == `Some(state)` means set it to `state`
-    pub(crate) fn set_or_toggle_ignore(&mut self, state: Option<bool>) {
+    pub(crate) fn set_or_toggle_status(&mut self, state: Option<bool>) {
         self.show_status = state.unwrap_or(!self.show_status);
         if self.show_status {
             self.add_client_notify_msg("Ignore disabled");

--- a/crates/libtiny_tui/src/notifier.rs
+++ b/crates/libtiny_tui/src/notifier.rs
@@ -1,19 +1,31 @@
 use crate::MsgTarget;
 
 use libtiny_wire::formatting::remove_irc_control_chars;
+use serde::Deserialize;
 
 #[cfg(feature = "desktop-notifications")]
 use notify_rust::Notification;
 
 /// Destktop notification handler
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum Notifier {
     /// Notifications are disabled.
     Off,
     /// Generate notifications only for mentions.
     Mentions,
-    /// Generate notificastions for all messages.
+    /// Generate notifications for all messages.
     Messages,
+}
+
+impl Default for Notifier {
+    fn default() -> Self {
+        if cfg!(feature = "desktop-notifications") {
+            Notifier::Mentions
+        } else {
+            Notifier::Off
+        }
+    }
 }
 
 #[cfg(feature = "desktop-notifications")]

--- a/crates/libtiny_tui/src/notifier.rs
+++ b/crates/libtiny_tui/src/notifier.rs
@@ -1,11 +1,12 @@
 use std::str::FromStr;
 
+use crate::MsgTarget;
+
 use libtiny_wire::formatting::remove_irc_control_chars;
+
 #[cfg(feature = "desktop-notifications")]
 use notify_rust::Notification;
 use serde::Deserialize;
-
-use crate::MsgTarget;
 
 /// Destktop notification handler
 #[derive(Debug, Deserialize, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]

--- a/crates/libtiny_tui/src/notifier.rs
+++ b/crates/libtiny_tui/src/notifier.rs
@@ -1,4 +1,5 @@
 use crate::MsgTarget;
+use std::str::FromStr;
 
 use libtiny_wire::formatting::remove_irc_control_chars;
 use serde::Deserialize;
@@ -9,7 +10,7 @@ use notify_rust::Notification;
 /// Destktop notification handler
 #[derive(Debug, Deserialize, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
-pub(crate) enum Notifier {
+pub enum Notifier {
     /// Notifications are disabled.
     Off,
     /// Generate notifications only for mentions.
@@ -24,6 +25,19 @@ impl Default for Notifier {
             Notifier::Mentions
         } else {
             Notifier::Off
+        }
+    }
+}
+
+impl FromStr for Notifier {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "off" => Ok(Notifier::Off),
+            "mentions" => Ok(Notifier::Mentions),
+            "messages" => Ok(Notifier::Messages),
+            _ => Err(format!("Unknown Notifier variant: {}", s)),
         }
     }
 }

--- a/crates/libtiny_tui/src/notifier.rs
+++ b/crates/libtiny_tui/src/notifier.rs
@@ -1,11 +1,11 @@
-use crate::MsgTarget;
 use std::str::FromStr;
 
 use libtiny_wire::formatting::remove_irc_control_chars;
-use serde::Deserialize;
-
 #[cfg(feature = "desktop-notifications")]
 use notify_rust::Notification;
+use serde::Deserialize;
+
+use crate::MsgTarget;
 
 /// Destktop notification handler
 #[derive(Debug, Deserialize, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]

--- a/crates/libtiny_tui/src/tab.rs
+++ b/crates/libtiny_tui/src/tab.rs
@@ -1,10 +1,12 @@
 use libtiny_common::{MsgSource, TabStyle};
 use termbox_simple::{Termbox, TB_UNDERLINE};
+
 use unicode_width::UnicodeWidthStr;
 
-use crate::config::{Colors, Style, TabConfigs};
-use crate::messaging::MessagingUI;
-use crate::notifier::Notifier;
+use crate::{
+    config::{Colors, Style},
+    messaging::MessagingUI,
+};
 
 pub(crate) struct Tab {
     pub(crate) visible_name: String,
@@ -13,7 +15,6 @@ pub(crate) struct Tab {
     pub(crate) style: TabStyle,
     /// Alt-character to use to switch to this tab.
     pub(crate) switch: Option<char>,
-    pub(crate) notifier: Notifier,
 }
 
 fn tab_style(style: TabStyle, colors: &Colors) -> Style {
@@ -68,19 +69,6 @@ impl Tab {
                 tb.change_cell(pos_x, pos_y, ch, style.fg, style.bg);
             }
             pos_x += 1;
-        }
-    }
-
-    pub(crate) fn update_config(&mut self, configs: &TabConfigs) {
-        let config = match &self.src {
-            MsgSource::Serv { serv } => configs.serv_conf(serv),
-            MsgSource::Chan { serv, chan } => configs.chan_conf(serv, chan.as_ref()),
-            MsgSource::User { .. } => None,
-        };
-        if let Some(config) = config {
-            self.widget
-                .set_or_toggle_status(Some(config.ignore.map(|i| !i).unwrap_or_default()));
-            self.notifier = config.notifier.unwrap_or(self.notifier);
         }
     }
 }

--- a/crates/libtiny_tui/src/tab.rs
+++ b/crates/libtiny_tui/src/tab.rs
@@ -1,13 +1,10 @@
 use libtiny_common::{MsgSource, TabStyle};
 use termbox_simple::{Termbox, TB_UNDERLINE};
-
 use unicode_width::UnicodeWidthStr;
 
-use crate::{
-    config::{Colors, Style},
-    messaging::MessagingUI,
-    notifier::Notifier,
-};
+use crate::config::{Colors, Style, TabConfigs};
+use crate::messaging::MessagingUI;
+use crate::notifier::Notifier;
 
 pub(crate) struct Tab {
     pub(crate) visible_name: String,
@@ -71,6 +68,19 @@ impl Tab {
                 tb.change_cell(pos_x, pos_y, ch, style.fg, style.bg);
             }
             pos_x += 1;
+        }
+    }
+
+    pub(crate) fn update_config(&mut self, configs: &TabConfigs) {
+        let config = match &self.src {
+            MsgSource::Serv { serv } => configs.serv_conf(serv),
+            MsgSource::Chan { serv, chan } => configs.chan_conf(serv, chan.as_ref()),
+            MsgSource::User { .. } => None,
+        };
+        if let Some(config) = config {
+            self.widget
+                .set_or_toggle_status(Some(config.ignore.map(|i| !i).unwrap_or_default()));
+            self.notifier = config.notifier.unwrap_or(self.notifier);
         }
     }
 }

--- a/crates/libtiny_tui/src/tests/config.rs
+++ b/crates/libtiny_tui/src/tests/config.rs
@@ -1,0 +1,107 @@
+use libtiny_common::ChanNameRef;
+
+use crate::config::*;
+use crate::notifier::Notifier;
+
+#[test]
+fn parsing_tab_configs() {
+    let config_str = r##"
+        servers:
+          - addr: "server"
+            join: 
+              - name: "#tiny"
+                ignore: false
+                notifier: messages
+            notifier: mentions
+          - addr: "server2"
+            join:
+              - "#tiny2" 
+        defaults:
+            ignore: true
+            notifier: off
+        "##;
+    let config: Config = serde_yaml::from_str(config_str).expect("parsed config");
+    let expected = Config {
+        servers: vec![
+            Server {
+                addr: "server".to_string(),
+                join: vec![Chan::WithConfigs {
+                    name: "#tiny".to_string(),
+                    configs: TabConfigs {
+                        ignore: Some(false),
+                        notifier: Some(Notifier::Messages),
+                    },
+                }],
+                configs: TabConfigs {
+                    ignore: None,
+                    notifier: Some(Notifier::Mentions),
+                },
+            },
+            Server {
+                addr: "server2".to_string(),
+                join: vec![Chan::Name("#tiny2".to_string())],
+                configs: TabConfigs {
+                    ignore: None,
+                    notifier: None,
+                },
+            },
+        ],
+        defaults: Defaults {
+            tab_configs: TabConfigs {
+                ignore: Some(true),
+                notifier: Some(Notifier::Off),
+            },
+        },
+        ..Default::default()
+    };
+    assert_eq!(config.servers, expected.servers);
+    assert_eq!(config.defaults, expected.defaults);
+
+    assert_eq!(
+        config.server_tab_configs("server"),
+        TabConfigs {
+            ignore: Some(true),                 // overwritten by defaults
+            notifier: Some(Notifier::Mentions)  // configured
+        }
+    );
+
+    assert_eq!(
+        config.server_tab_configs("server2"),
+        TabConfigs {
+            ignore: Some(true),            // overwritten by defaults
+            notifier: Some(Notifier::Off)  // overwritten by defaults
+        }
+    );
+
+    assert_eq!(
+        config.server_tab_configs("randomserver"),
+        TabConfigs {
+            ignore: Some(true),            // defaults
+            notifier: Some(Notifier::Off)  // defaults
+        }
+    );
+
+    assert_eq!(
+        config.chan_tab_configs("server", ChanNameRef::new("#tiny")),
+        TabConfigs {
+            ignore: Some(false),                // configured
+            notifier: Some(Notifier::Messages)  // configured
+        }
+    );
+
+    assert_eq!(
+        config.chan_tab_configs("server", ChanNameRef::new("##rust")),
+        TabConfigs {
+            ignore: Some(true),                 // overwritten by defaults
+            notifier: Some(Notifier::Mentions)  // overwritten by server
+        }
+    );
+
+    assert_eq!(
+        config.chan_tab_configs("server2", ChanNameRef::new("#tiny2")),
+        TabConfigs {
+            ignore: Some(true),            // overwritten by defaults
+            notifier: Some(Notifier::Off)  // overwritten by defaults
+        }
+    );
+}

--- a/crates/libtiny_tui/src/tests/config.rs
+++ b/crates/libtiny_tui/src/tests/config.rs
@@ -20,41 +20,39 @@ fn parsing_tab_configs() {
             notifier: off
         "##;
     let config: Config = serde_yaml::from_str(config_str).expect("parsed config");
+    let tab_configs: TabConfigs = (&config).into();
     let expected = Config {
         servers: vec![
             Server {
                 addr: "server".to_string(),
                 join: vec![Chan {
                     name: ChanName::new("#tiny".to_string()),
-                    config: TabConfig {
-                        ignore: Some(true),
-                        notifier: Some(Notifier::Messages),
-                    },
+                    config: Some(TabConfig {
+                        ignore: true,
+                        notifier: Notifier::Messages,
+                    }),
                 }],
-                configs: TabConfig {
-                    ignore: None,
-                    notifier: Some(Notifier::Mentions),
-                },
+                config: Some(TabConfig {
+                    notifier: Notifier::Mentions,
+                    ..Default::default()
+                }),
             },
             Server {
                 addr: "server2".to_string(),
                 join: vec![Chan {
                     name: ChanName::new("#tiny2".to_string()),
-                    config: TabConfig {
-                        ignore: None,
-                        notifier: None,
-                    },
+                    config: None,
                 }],
-                configs: TabConfig {
-                    ignore: Some(true),
-                    notifier: None,
-                },
+                config: Some(TabConfig {
+                    ignore: true,
+                    ..Default::default()
+                }),
             },
         ],
         defaults: Defaults {
-            tab_configs: TabConfig {
-                ignore: Some(false),
-                notifier: Some(Notifier::Off),
+            tab_config: TabConfig {
+                ignore: false,
+                notifier: Notifier::Off,
             },
         },
         ..Default::default()
@@ -63,50 +61,41 @@ fn parsing_tab_configs() {
     assert_eq!(config.defaults, expected.defaults);
 
     assert_eq!(
-        config.server_tab_configs("server"),
-        TabConfig {
-            ignore: Some(false),                // overwritten by defaults
-            notifier: Some(Notifier::Mentions)  // configured
-        }
+        tab_configs.serv_conf("server"),
+        Some(TabConfig {
+            ignore: false,                // overwritten by defaults
+            notifier: Notifier::Mentions  // configured
+        })
     );
 
     assert_eq!(
-        config.server_tab_configs("server2"),
-        TabConfig {
-            ignore: Some(true),            // configured
-            notifier: Some(Notifier::Off)  // overwritten by defaults
-        }
+        tab_configs.serv_conf("server2"),
+        Some(TabConfig {
+            ignore: true,            // configured
+            notifier: Notifier::Off  // overwritten by defaults
+        })
+    );
+
+    assert_eq!(tab_configs.serv_conf("randomserver"), None);
+
+    assert_eq!(
+        tab_configs.chan_conf("server", ChanNameRef::new("#tiny")),
+        Some(&TabConfig {
+            ignore: true,                 // configured
+            notifier: Notifier::Messages  // configured
+        })
     );
 
     assert_eq!(
-        config.server_tab_configs("randomserver"),
-        TabConfig {
-            ignore: Some(false),           // defaults
-            notifier: Some(Notifier::Off)  // defaults
-        }
+        tab_configs.chan_conf("server", ChanNameRef::new("##rust")),
+        None
     );
 
     assert_eq!(
-        config.chan_tab_configs("server", ChanNameRef::new("#tiny")),
-        TabConfig {
-            ignore: Some(true),                 // configured
-            notifier: Some(Notifier::Messages)  // configured
-        }
-    );
-
-    assert_eq!(
-        config.chan_tab_configs("server", ChanNameRef::new("##rust")),
-        TabConfig {
-            ignore: Some(false),                // overwritten by defaults
-            notifier: Some(Notifier::Mentions)  // overwritten by server
-        }
-    );
-
-    assert_eq!(
-        config.chan_tab_configs("server2", ChanNameRef::new("#tiny2")),
-        TabConfig {
-            ignore: Some(true),            // overwritten by server
-            notifier: Some(Notifier::Off)  // overwritten by defaults
-        }
+        tab_configs.chan_conf("server2", ChanNameRef::new("#tiny2")),
+        Some(&TabConfig {
+            ignore: true,            // overwritten by server
+            notifier: Notifier::Off  // overwritten by defaults
+        })
     );
 }

--- a/crates/libtiny_tui/src/tests/config.rs
+++ b/crates/libtiny_tui/src/tests/config.rs
@@ -9,15 +9,17 @@ fn parsing_tab_configs() {
         servers:
           - addr: "server"
             join: 
-              - "#tiny -ignore -notify messages"
-            notifier: mentions
+              - name: "#tiny"
+                ignore: true
+                notify: "messages"
+            notify: "mentions"
           - addr: "server2"
             join:
               - "#tiny2" 
             ignore: true
         defaults:
             ignore: false
-            notifier: off
+            notify: off
         "##;
     let config: Config = serde_yaml::from_str(config_str).expect("parsed config");
     let tab_configs: TabConfigs = (&config).into();
@@ -25,24 +27,21 @@ fn parsing_tab_configs() {
         servers: vec![
             Server {
                 addr: "server".to_string(),
-                join: vec![Chan {
+                join: vec![Chan::WithConfig {
                     name: ChanName::new("#tiny".to_string()),
                     config: TabConfig {
                         ignore: Some(true),
-                        notifier: Some(Notifier::Messages),
+                        notify: Some(Notifier::Messages),
                     },
                 }],
                 config: TabConfig {
-                    notifier: Some(Notifier::Mentions),
+                    notify: Some(Notifier::Mentions),
                     ..Default::default()
                 },
             },
             Server {
                 addr: "server2".to_string(),
-                join: vec![Chan {
-                    name: ChanName::new("#tiny2".to_string()),
-                    config: TabConfig::default(),
-                }],
+                join: vec![Chan::Name(ChanName::new("#tiny2".to_string()))],
                 config: TabConfig {
                     ignore: Some(true),
                     ..Default::default()
@@ -52,7 +51,7 @@ fn parsing_tab_configs() {
         defaults: Defaults {
             tab_config: TabConfig {
                 ignore: Some(false),
-                notifier: Some(Notifier::Off),
+                notify: Some(Notifier::Off),
             },
         },
         ..Default::default()
@@ -61,41 +60,41 @@ fn parsing_tab_configs() {
     assert_eq!(config.defaults, expected.defaults);
 
     assert_eq!(
-        tab_configs.serv_conf("server"),
+        tab_configs.get("server", None),
         Some(TabConfig {
-            ignore: Some(false),                // overwritten by defaults
-            notifier: Some(Notifier::Mentions)  // configured
+            ignore: Some(false),              // overwritten by defaults
+            notify: Some(Notifier::Mentions)  // configured
         })
     );
 
     assert_eq!(
-        tab_configs.serv_conf("server2"),
+        tab_configs.get("server2", None),
         Some(TabConfig {
-            ignore: Some(true),                  // configured
-            notifier: Some(Notifier::default())  // overwritten by defaults
+            ignore: Some(true),                // configured
+            notify: Some(Notifier::default())  // overwritten by defaults
         })
     );
 
-    assert_eq!(tab_configs.serv_conf("randomserver"), None);
+    assert_eq!(tab_configs.get("randomserver", None), None);
 
     assert_eq!(
-        tab_configs.chan_conf("server", ChanNameRef::new("#tiny")),
+        tab_configs.get("server", Some(ChanNameRef::new("#tiny"))),
         Some(TabConfig {
-            ignore: Some(true),                 // configured
-            notifier: Some(Notifier::Messages)  // configured
+            ignore: Some(true),               // configured
+            notify: Some(Notifier::Messages)  // configured
         })
     );
 
     assert_eq!(
-        tab_configs.chan_conf("server", ChanNameRef::new("##rust")),
+        tab_configs.get("server", Some(ChanNameRef::new("##rust"))),
         None
     );
 
     assert_eq!(
-        tab_configs.chan_conf("server2", ChanNameRef::new("#tiny2")),
+        tab_configs.get("server2", Some(ChanNameRef::new("#tiny2"))),
         Some(TabConfig {
-            ignore: Some(true),            // overwritten by server
-            notifier: Some(Notifier::Off)  // overwritten by defaults
+            ignore: Some(true),          // overwritten by server
+            notify: Some(Notifier::Off)  // overwritten by defaults
         })
     );
 }

--- a/crates/libtiny_tui/src/tests/config.rs
+++ b/crates/libtiny_tui/src/tests/config.rs
@@ -27,32 +27,32 @@ fn parsing_tab_configs() {
                 addr: "server".to_string(),
                 join: vec![Chan {
                     name: ChanName::new("#tiny".to_string()),
-                    config: Some(TabConfig {
-                        ignore: true,
-                        notifier: Notifier::Messages,
-                    }),
+                    config: TabConfig {
+                        ignore: Some(true),
+                        notifier: Some(Notifier::Messages),
+                    },
                 }],
-                config: Some(TabConfig {
-                    notifier: Notifier::Mentions,
+                config: TabConfig {
+                    notifier: Some(Notifier::Mentions),
                     ..Default::default()
-                }),
+                },
             },
             Server {
                 addr: "server2".to_string(),
                 join: vec![Chan {
                     name: ChanName::new("#tiny2".to_string()),
-                    config: None,
+                    config: TabConfig::default(),
                 }],
-                config: Some(TabConfig {
-                    ignore: true,
+                config: TabConfig {
+                    ignore: Some(true),
                     ..Default::default()
-                }),
+                },
             },
         ],
         defaults: Defaults {
             tab_config: TabConfig {
-                ignore: false,
-                notifier: Notifier::Off,
+                ignore: Some(false),
+                notifier: Some(Notifier::Off),
             },
         },
         ..Default::default()
@@ -63,16 +63,16 @@ fn parsing_tab_configs() {
     assert_eq!(
         tab_configs.serv_conf("server"),
         Some(TabConfig {
-            ignore: false,                // overwritten by defaults
-            notifier: Notifier::Mentions  // configured
+            ignore: Some(false),                // overwritten by defaults
+            notifier: Some(Notifier::Mentions)  // configured
         })
     );
 
     assert_eq!(
         tab_configs.serv_conf("server2"),
         Some(TabConfig {
-            ignore: true,            // configured
-            notifier: Notifier::Off  // overwritten by defaults
+            ignore: Some(true),                  // configured
+            notifier: Some(Notifier::default())  // overwritten by defaults
         })
     );
 
@@ -81,8 +81,8 @@ fn parsing_tab_configs() {
     assert_eq!(
         tab_configs.chan_conf("server", ChanNameRef::new("#tiny")),
         Some(&TabConfig {
-            ignore: true,                 // configured
-            notifier: Notifier::Messages  // configured
+            ignore: Some(true),                 // configured
+            notifier: Some(Notifier::Messages)  // configured
         })
     );
 
@@ -94,8 +94,8 @@ fn parsing_tab_configs() {
     assert_eq!(
         tab_configs.chan_conf("server2", ChanNameRef::new("#tiny2")),
         Some(&TabConfig {
-            ignore: true,            // overwritten by server
-            notifier: Notifier::Off  // overwritten by defaults
+            ignore: Some(true),            // overwritten by server
+            notifier: Some(Notifier::Off)  // overwritten by defaults
         })
     );
 }

--- a/crates/libtiny_tui/src/tests/config.rs
+++ b/crates/libtiny_tui/src/tests/config.rs
@@ -80,7 +80,7 @@ fn parsing_tab_configs() {
 
     assert_eq!(
         tab_configs.chan_conf("server", ChanNameRef::new("#tiny")),
-        Some(&TabConfig {
+        Some(TabConfig {
             ignore: Some(true),                 // configured
             notifier: Some(Notifier::Messages)  // configured
         })
@@ -93,7 +93,7 @@ fn parsing_tab_configs() {
 
     assert_eq!(
         tab_configs.chan_conf("server2", ChanNameRef::new("#tiny2")),
-        Some(&TabConfig {
+        Some(TabConfig {
             ignore: Some(true),            // overwritten by server
             notifier: Some(Notifier::Off)  // overwritten by defaults
         })

--- a/crates/libtiny_tui/src/tests/mod.rs
+++ b/crates/libtiny_tui/src/tests/mod.rs
@@ -9,6 +9,8 @@ use crate::tui::TUI;
 mod layout;
 mod resize;
 
+mod config;
+
 fn enter_string(tui: &mut TUI, s: &str) {
     for c in s.chars() {
         tui.handle_input_event(Event::Key(Key::Char(c)), &mut None);

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -1297,7 +1297,7 @@ impl TUI {
     /// An error message coming from Tiny, probably because of a command error
     /// etc. Those are not timestamped and not logged.
     pub(crate) fn add_client_err_msg(&mut self, msg: &str, target: &MsgTarget) {
-        self.apply_to_target(target, false, &|tab: &mut Tab, _| {
+        self.apply_to_target(target, true, &|tab: &mut Tab, _| {
             tab.widget.add_client_err_msg(msg);
         });
     }

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -444,20 +444,23 @@ impl TUI {
         };
         let status = !ignore.unwrap_or_default();
 
-        self.tabs.insert(idx, Tab {
-            visible_name,
-            widget: MessagingUI::new(
-                self.width,
-                self.height - 1,
-                status,
-                self.scrollback,
-                self.msg_layout,
-            ),
-            src,
-            style: TabStyle::Normal,
-            switch,
-            notifier: notifier.unwrap_or_default(),
-        });
+        self.tabs.insert(
+            idx,
+            Tab {
+                visible_name,
+                widget: MessagingUI::new(
+                    self.width,
+                    self.height - 1,
+                    status,
+                    self.scrollback,
+                    self.msg_layout,
+                ),
+                src,
+                style: TabStyle::Normal,
+                switch,
+                notifier: notifier.unwrap_or_default(),
+            },
+        );
     }
 
     /// Returns index of the new tab if a new tab is created.

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -427,15 +427,10 @@ impl TUI {
                     let server_tab_config = self
                         .tabs
                         .iter()
-                        .find_map(|tab| {
-                            if tab.src.serv_name() == serv {
-                                Some(TabConfig {
-                                    ignore: Some(!tab.widget.is_showing_status()),
-                                    notifier: Some(tab.notifier),
-                                })
-                            } else {
-                                None
-                            }
+                        .find(|tab| tab.src.serv_name() == serv)
+                        .map(|tab| TabConfig {
+                            ignore: Some(!tab.widget.is_showing_status()),
+                            notifier: Some(tab.notifier),
                         })
                         .expect("Creating a channel or user tab, but the server tab doesn't exist");
                     server_tab_config.merge(Some(&tab_configs))

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -10,13 +10,15 @@ servers:
       # alias: OFTC
 
       # Channels to automatically join
-      # Can include channel config arguments
-      # -ignore: ignores join/part messages
-      # -notify [off | mentions | messages]: sets notifier
-      # join:
-      #   - "#tiny -ignore -notify off"
+      # Can include tab config arguments
+      # -ignore: [true | false] -- ignores join/part messages
+      # -notify: [off | mentions | messages] -- sets notifications
       join:
           - "#tiny"
+      # join:
+      #   - name: "#tiny"
+      #     ignore: true
+      #     notify: "mentions"
 
       # Three authentication methods: pass, sasl, and nickserv_ident
       # These are optional and you probably only need one of these, delete
@@ -37,8 +39,8 @@ servers:
       # Set /ignore for this server and all its tabs, default: false
       # ignore: true  
 
-      # Set notifier for this server and all its tabs, default: mentions
-      # notifier: [off | mentions | messages]
+      # Set notifications for this server and all its tabs, default: mentions
+      # notify: [off | mentions | messages]
 
 # Defaults used when connecting to servers via the /connect command
 defaults:
@@ -50,8 +52,8 @@ defaults:
     # Set /ignore as the default for all servers and all its tabs, default: false
     # ignore: true 
 
-    # Set notifier as the default for all servers and all its tabs, default: mentions
-    # notifier: [off | mentions | messages]
+    # Set default notifications for all servers and all its tabs, default: mentions
+    # notify: [off | mentions | messages]
 
 # Where to put log files
 log_dir: "{}"

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -38,7 +38,7 @@ servers:
       # ignore: true  
 
       # Set notifier for this server and all its tabs, default: mentions
-      # notifier: <off | mentions | messages>
+      # notifier: [off | mentions | messages]
 
 # Defaults used when connecting to servers via the /connect command
 defaults:
@@ -51,7 +51,7 @@ defaults:
     # ignore: true 
 
     # Set notifier for all servers and all its tabs, default: mentions
-    # notifier: <off | mentions | messages>
+    # notifier: [off | mentions | messages]
 
 # Where to put log files
 log_dir: "{}"

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -47,10 +47,10 @@ defaults:
     join: []
     tls: false
 
-    # Set /ignore for all servers and all its tabs, default: false
+    # Set /ignore as the default for all servers and all its tabs, default: false
     # ignore: true 
 
-    # Set notifier for all servers and all its tabs, default: mentions
+    # Set notifier as the default for all servers and all its tabs, default: mentions
     # notifier: [off | mentions | messages]
 
 # Where to put log files

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -10,6 +10,11 @@ servers:
       # alias: OFTC
 
       # Channels to automatically join
+      # Can be represented as a String or map with configs
+      # join:
+      #   - name: "#tiny"
+      #     ignore: false
+      #     notifier: <off | mentions | messages>
       join:
           - "#tiny"
 
@@ -29,12 +34,24 @@ servers:
       # (useful when `pass` or `sasl` fields above are not used)
       # nickserv_ident: 'hunter2'
 
+      # Set /ignore for this server and all its tabs, default: false
+      # ignore: true  
+
+      # Set notifier for this server and all its tabs, default: mentions
+      # notifier: <off | mentions | messages>
+
 # Defaults used when connecting to servers via the /connect command
 defaults:
     nicks: [tiny_user]
     realname: yourname
     join: []
     tls: false
+
+    # Set /ignore for all servers and all its tabs, default: false
+    # ignore: true 
+
+    # Set notifier for all servers and all its tabs, default: mentions
+    # notifier: <off | mentions | messages>
 
 # Where to put log files
 log_dir: "{}"

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -10,11 +10,11 @@ servers:
       # alias: OFTC
 
       # Channels to automatically join
-      # Can be represented as a String or map with configs
+      # Can include channel config arguments
+      # -ignore: ignores join/part messages
+      # -notify [off | mentions | messages]: sets notifier
       # join:
-      #   - name: "#tiny"
-      #     ignore: false
-      #     notifier: <off | mentions | messages>
+      #   - "#tiny -ignore -notify off"
       join:
           - "#tiny"
 

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -292,7 +292,7 @@ static JOIN_CMD: Cmd = Cmd {
     name: "join",
     cmd_fn: join,
     description: "Joins a channel",
-    usage: "`/join <chan1>,<chan2>,...` or `/join` in a channel tab to rejoin",
+    usage: "`/join <chan1> <chan2>,...` or `/join` in a channel tab to rejoin",
 };
 
 fn join(args: CmdArgs) {

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -211,9 +211,12 @@ fn connect(args: CmdArgs) {
 
 fn reconnect(ui: &UI, clients: &mut [Client], src: MsgSource) {
     if let Some(client) = find_client(clients, src.serv_name()) {
-        ui.add_client_msg("Reconnecting...", &MsgTarget::AllServTabs {
-            serv: src.serv_name(),
-        });
+        ui.add_client_msg(
+            "Reconnecting...",
+            &MsgTarget::AllServTabs {
+                serv: src.serv_name(),
+            },
+        );
         client.reconnect(None);
     }
 }
@@ -356,10 +359,13 @@ fn join(args: CmdArgs) {
             let iter_ref = chans.iter().map(|c| c.name.as_ref());
             // set tab configs of new channel tabs (creates new tab)
             for chan in &chans {
-                ui.set_tab_config(chan.config, &MsgTarget::Chan {
-                    chan: &chan.name,
-                    serv: serv_name,
-                })
+                ui.set_tab_config(
+                    chan.config,
+                    &MsgTarget::Chan {
+                        chan: &chan.name,
+                        serv: serv_name,
+                    },
+                )
             }
             client.join(iter_ref);
         }

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -1,12 +1,13 @@
+use std::borrow::Borrow;
+use std::str::FromStr;
+
+use libtiny_client::{Client, ServerInfo};
+use libtiny_common::{ChanNameRef, MsgSource, MsgTarget};
+use libtiny_tui::config::{Chan, TabConfig};
+
 use crate::config::Defaults;
 use crate::ui::UI;
 use crate::utils;
-use libtiny_client::{Client, ServerInfo};
-use libtiny_common::{ChanNameRef, MsgSource, MsgTarget};
-use libtiny_tui::config::Chan;
-
-use std::borrow::Borrow;
-use std::str::FromStr;
 
 pub(crate) struct CmdArgs<'a> {
     pub args: &'a str,
@@ -17,7 +18,8 @@ pub(crate) struct CmdArgs<'a> {
 }
 
 pub(crate) struct Cmd {
-    /// Command name. E.g. if this is `"cmd"`, `/cmd ...` will call this command.
+    /// Command name. E.g. if this is `"cmd"`, `/cmd ...` will call this
+    /// command.
     pub(crate) name: &'static str,
     /// Command function.
     pub(crate) cmd_fn: fn(CmdArgs),
@@ -73,8 +75,8 @@ pub(crate) fn parse_cmd(cmd: &str) -> ParseCmdResult {
             //             rest,
             //         },
             //     _ =>
-            //         ParseCmdResult::Ambiguous(possibilities.into_iter().map(|cmd| cmd.name).collect()),
-            // }
+            //         ParseCmdResult::Ambiguous(possibilities.into_iter().
+            // map(|cmd| cmd.name).collect()), }
         }
     }
 }
@@ -209,12 +211,9 @@ fn connect(args: CmdArgs) {
 
 fn reconnect(ui: &UI, clients: &mut [Client], src: MsgSource) {
     if let Some(client) = find_client(clients, src.serv_name()) {
-        ui.add_client_msg(
-            "Reconnecting...",
-            &MsgTarget::AllServTabs {
-                serv: src.serv_name(),
-            },
-        );
+        ui.add_client_msg("Reconnecting...", &MsgTarget::AllServTabs {
+            serv: src.serv_name(),
+        });
         client.reconnect(None);
     }
 }
@@ -337,7 +336,7 @@ fn join(args: CmdArgs) {
             Some(MsgSource::Chan { serv: _, chan }) => {
                 vec![Chan {
                     name: chan,
-                    config: None,
+                    config: TabConfig::user_tab_config(),
                 }]
             }
             Some(_) => {
@@ -357,15 +356,10 @@ fn join(args: CmdArgs) {
             let iter_ref = chans.iter().map(|c| c.name.as_ref());
             // set tab configs of new channel tabs (creates new tab)
             for chan in &chans {
-                if let Some(tab_config) = chan.config {
-                    ui.set_tab_config(
-                        tab_config,
-                        &MsgTarget::Chan {
-                            chan: &chan.name,
-                            serv: serv_name,
-                        },
-                    )
-                }
+                ui.set_tab_config(chan.config, &MsgTarget::Chan {
+                    chan: &chan.name,
+                    serv: serv_name,
+                })
             }
             client.join(iter_ref);
         }
@@ -411,9 +405,10 @@ static MSG_CMD: Cmd = Cmd {
 fn split_msg_args(args: &str) -> Option<(&str, &str)> {
     let mut char_indices = args.char_indices();
 
-    // We could check for validity of the nick according to RFC 2812 but we do the simple thing for
-    // now and and only check the first character, to avoid confusing the UI by returning a
-    // `MsgSource::User` with a channel name as `nick`.
+    // We could check for validity of the nick according to RFC 2812 but we do the
+    // simple thing for now and and only check the first character, to avoid
+    // confusing the UI by returning a `MsgSource::User` with a channel name as
+    // `nick`.
     match char_indices.next() {
         None => {
             return None;

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -3,7 +3,7 @@ use crate::ui::UI;
 use crate::utils;
 use libtiny_client::{Client, ServerInfo};
 use libtiny_common::{ChanNameRef, MsgSource, MsgTarget};
-use libtiny_tui::config::{Chan, TabConfig};
+use libtiny_tui::config::Chan;
 
 use std::borrow::Borrow;
 use std::str::FromStr;
@@ -337,7 +337,7 @@ fn join(args: CmdArgs) {
             Some(MsgSource::Chan { serv: _, chan }) => {
                 vec![Chan {
                     name: chan,
-                    config: TabConfig::default(),
+                    config: None,
                 }]
             }
             Some(_) => {
@@ -357,13 +357,15 @@ fn join(args: CmdArgs) {
             let iter_ref = chans.iter().map(|c| c.name.as_ref());
             // set tab configs of new channel tabs (creates new tab)
             for chan in &chans {
-                ui.set_tab_config(
-                    chan.config,
-                    &MsgTarget::Chan {
-                        chan: &chan.name,
-                        serv: serv_name,
-                    },
-                )
+                if let Some(tab_config) = chan.config {
+                    ui.set_tab_config(
+                        tab_config,
+                        &MsgTarget::Chan {
+                            chan: &chan.name,
+                            serv: serv_name,
+                        },
+                    )
+                }
             }
             client.join(iter_ref);
         }

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -36,17 +36,15 @@ pub(crate) struct Server {
     #[serde(deserialize_with = "deser_trimmed_str")]
     pub(crate) realname: String,
 
-    /// Nicks to try when connecting to this server. tiny tries these
-    /// sequentially, and starts adding trailing underscores to the last one
-    /// if none of the nicks are available.
+    /// Nicks to try when connecting to this server. tiny tries these sequentially, and starts
+    /// adding trailing underscores to the last one if none of the nicks are available.
     #[serde(deserialize_with = "deser_trimmed_str_vec")]
     pub(crate) nicks: Vec<String>,
 
     /// Channels to automatically join.
     pub(crate) join: Vec<Chan>,
 
-    /// NickServ identification password. Used on connecting to the server and
-    /// nick change.
+    /// NickServ identification password. Used on connecting to the server and nick change.
     pub(crate) nickserv_ident: Option<String>,
 
     /// Authenication method

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -231,7 +231,7 @@ mod tests {
                     servers[0].join,
                     vec![Chan {
                         name: ChanName::new("#tiny".to_string()),
-                        config: TabConfig::default()
+                        config: None,
                     }]
                 );
                 assert_eq!(servers[0].tls, true);
@@ -293,10 +293,10 @@ mod tests {
             config.servers[0].join,
             vec![Chan {
                 name: ChanName::new("#tiny".to_string()),
-                config: TabConfig {
-                    ignore: Some(true),
-                    notifier: Some(Notifier::Off)
-                }
+                config: Some(TabConfig {
+                    ignore: true,
+                    notifier: Notifier::Off
+                })
             }]
         );
     }

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -1,9 +1,10 @@
-use libtiny_tui::config::Chan;
-use serde::{Deserialize, Deserializer};
 use std::fs;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+use libtiny_tui::config::Chan;
+use serde::{Deserialize, Deserializer};
 
 #[derive(Clone, Deserialize, Debug, PartialEq, Eq)]
 pub(crate) struct SASLAuth {
@@ -35,8 +36,9 @@ pub(crate) struct Server {
     #[serde(deserialize_with = "deser_trimmed_str")]
     pub(crate) realname: String,
 
-    /// Nicks to try when connecting to this server. tiny tries these sequentially, and starts
-    /// adding trailing underscores to the last one if none of the nicks are available.
+    /// Nicks to try when connecting to this server. tiny tries these
+    /// sequentially, and starts adding trailing underscores to the last one
+    /// if none of the nicks are available.
     #[serde(deserialize_with = "deser_trimmed_str_vec")]
     pub(crate) nicks: Vec<String>,
 
@@ -44,7 +46,8 @@ pub(crate) struct Server {
     // #[serde(default, deserialize_with = "deser_chans")]
     pub(crate) join: Vec<Chan>,
 
-    /// NickServ identification password. Used on connecting to the server and nick change.
+    /// NickServ identification password. Used on connecting to the server and
+    /// nick change.
     pub(crate) nickserv_ident: Option<String>,
 
     /// Authenication method
@@ -148,7 +151,8 @@ impl Config {
 /// - $HOME/.config/tiny/config.yml
 /// - $HOME/.tinyrc.yml (old, for backward compat)
 ///
-/// Panics when none of $XDG_CONFIG_HOME or $HOME can be found (using the `dirs` crate).
+/// Panics when none of $XDG_CONFIG_HOME or $HOME can be found (using the `dirs`
+/// crate).
 pub(crate) fn get_config_path() -> PathBuf {
     let xdg_config_path = dirs::config_dir().map(|mut xdg_config_home| {
         xdg_config_home.push("tiny");
@@ -213,11 +217,12 @@ fn get_default_config_yaml() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libtiny_common::ChanName;
     use libtiny_tui::config::TabConfig;
     use libtiny_tui::Notifier;
     use serde_yaml;
+
+    use super::*;
 
     #[test]
     fn parse_default_config() {
@@ -227,13 +232,10 @@ mod tests {
                 panic!();
             }
             Ok(Config { servers, .. }) => {
-                assert_eq!(
-                    servers[0].join,
-                    vec![Chan {
-                        name: ChanName::new("#tiny".to_string()),
-                        config: None,
-                    }]
-                );
+                assert_eq!(servers[0].join, vec![Chan {
+                    name: ChanName::new("#tiny".to_string()),
+                    config: TabConfig::default(),
+                }]);
                 assert_eq!(servers[0].tls, true);
             }
         }
@@ -241,8 +243,9 @@ mod tests {
 
     #[test]
     fn validation() {
-        // We trim the string fields when deserializing, so `validate` doesn't consider non-empty
-        // strings as empty even if they have only spaces, it assumes spaces should be trimmed
+        // We trim the string fields when deserializing, so `validate` doesn't consider
+        // non-empty strings as empty even if they have only spaces, it assumes
+        // spaces should be trimmed
         let config = Config {
             servers: vec![Server {
                 addr: "my_server".to_owned(),
@@ -289,15 +292,12 @@ mod tests {
             &get_default_config_yaml().replace("#tiny", "#tiny -ignore -notify off"),
         )
         .expect("parsed config");
-        assert_eq!(
-            config.servers[0].join,
-            vec![Chan {
-                name: ChanName::new("#tiny".to_string()),
-                config: Some(TabConfig {
-                    ignore: true,
-                    notifier: Notifier::Off
-                })
-            }]
-        );
+        assert_eq!(config.servers[0].join, vec![Chan {
+            name: ChanName::new("#tiny".to_string()),
+            config: TabConfig {
+                ignore: Some(true),
+                notifier: Some(Notifier::Off)
+            }
+        }]);
     }
 }

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -1,6 +1,5 @@
+use libtiny_tui::config::Chan;
 use serde::{Deserialize, Deserializer};
-use serde_yaml::Value;
-use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -42,7 +41,7 @@ pub(crate) struct Server {
     pub(crate) nicks: Vec<String>,
 
     /// Channels to automatically join.
-    #[serde(default)]
+    // #[serde(default, deserialize_with = "deser_chans")]
     pub(crate) join: Vec<Chan>,
 
     /// NickServ identification password. Used on connecting to the server and nick change.
@@ -64,28 +63,6 @@ pub(crate) struct Defaults {
     pub(crate) join: Vec<String>,
     #[serde(default)]
     pub(crate) tls: bool,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub(crate) enum Chan {
-    /// Channel specified by name only
-    Name(String),
-    /// Channel specified by name with extra configuration (used by tui crate)
-    WithExtra {
-        name: String,
-        #[serde(flatten)]
-        extra: HashMap<String, Value>,
-    },
-}
-
-impl Chan {
-    pub(crate) fn name(&self) -> &str {
-        match self {
-            Chan::Name(name) => name,
-            Chan::WithExtra { name, .. } => name,
-        }
-    }
 }
 
 #[derive(Deserialize)]
@@ -237,6 +214,10 @@ fn get_default_config_yaml() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libtiny_common::ChanName;
+    use libtiny_tui::config::TabConfig;
+    use libtiny_tui::Notifier;
+    use serde_yaml;
 
     #[test]
     fn parse_default_config() {
@@ -246,7 +227,13 @@ mod tests {
                 panic!();
             }
             Ok(Config { servers, .. }) => {
-                assert_eq!(servers[0].join, vec![Chan::Name("#tiny".to_owned())]);
+                assert_eq!(
+                    servers[0].join,
+                    vec![Chan {
+                        name: ChanName::new("#tiny".to_string()),
+                        config: TabConfig::default()
+                    }]
+                );
                 assert_eq!(servers[0].tls, true);
             }
         }
@@ -297,23 +284,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_chan_config() {
-        let config = r##"- "#tiny""##;
+    fn parse_chan_with_args() {
+        let config: Config = serde_yaml::from_str(
+            &get_default_config_yaml().replace("#tiny", "#tiny -ignore -notify off"),
+        )
+        .expect("parsed config");
         assert_eq!(
-            serde_yaml::from_str::<Vec<Chan>>(config).unwrap(),
-            vec![Chan::Name("#tiny".to_string())]
-        );
-        let config = r##"
-        - name: "#tiny"
-          ignore: true
-        "##;
-        let mut extra = HashMap::new();
-        extra.insert("ignore".to_string(), Value::Bool(true));
-        assert_eq!(
-            serde_yaml::from_str::<Vec<Chan>>(config).unwrap(),
-            vec![Chan::WithExtra {
-                name: "#tiny".to_string(),
-                extra
+            config.servers[0].join,
+            vec![Chan {
+                name: ChanName::new("#tiny".to_string()),
+                config: TabConfig {
+                    ignore: Some(true),
+                    notifier: Some(Notifier::Off)
+                }
             }]
         );
     }

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -232,10 +232,13 @@ mod tests {
                 panic!();
             }
             Ok(Config { servers, .. }) => {
-                assert_eq!(servers[0].join, vec![Chan {
-                    name: ChanName::new("#tiny".to_string()),
-                    config: TabConfig::default(),
-                }]);
+                assert_eq!(
+                    servers[0].join,
+                    vec![Chan {
+                        name: ChanName::new("#tiny".to_string()),
+                        config: TabConfig::default(),
+                    }]
+                );
                 assert_eq!(servers[0].tls, true);
             }
         }
@@ -292,12 +295,15 @@ mod tests {
             &get_default_config_yaml().replace("#tiny", "#tiny -ignore -notify off"),
         )
         .expect("parsed config");
-        assert_eq!(config.servers[0].join, vec![Chan {
-            name: ChanName::new("#tiny".to_string()),
-            config: TabConfig {
-                ignore: Some(true),
-                notifier: Some(Notifier::Off)
-            }
-        }]);
+        assert_eq!(
+            config.servers[0].join,
+            vec![Chan {
+                name: ChanName::new("#tiny".to_string()),
+                config: TabConfig {
+                    ignore: Some(true),
+                    notifier: Some(Notifier::Off)
+                }
+            }]
+        );
     }
 }

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -43,7 +43,6 @@ pub(crate) struct Server {
     pub(crate) nicks: Vec<String>,
 
     /// Channels to automatically join.
-    // #[serde(default, deserialize_with = "deser_chans")]
     pub(crate) join: Vec<Chan>,
 
     /// NickServ identification password. Used on connecting to the server and
@@ -151,8 +150,7 @@ impl Config {
 /// - $HOME/.config/tiny/config.yml
 /// - $HOME/.tinyrc.yml (old, for backward compat)
 ///
-/// Panics when none of $XDG_CONFIG_HOME or $HOME can be found (using the `dirs`
-/// crate).
+/// Panics when none of $XDG_CONFIG_HOME or $HOME can be found (using the `dirs` crate).
 pub(crate) fn get_config_path() -> PathBuf {
     let xdg_config_path = dirs::config_dir().map(|mut xdg_config_home| {
         xdg_config_home.push("tiny");
@@ -218,8 +216,6 @@ fn get_default_config_yaml() -> String {
 #[cfg(test)]
 mod tests {
     use libtiny_common::ChanName;
-    use libtiny_tui::config::TabConfig;
-    use libtiny_tui::Notifier;
     use serde_yaml;
 
     use super::*;
@@ -234,10 +230,7 @@ mod tests {
             Ok(Config { servers, .. }) => {
                 assert_eq!(
                     servers[0].join,
-                    vec![Chan {
-                        name: ChanName::new("#tiny".to_string()),
-                        config: TabConfig::default(),
-                    }]
+                    vec![Chan::Name(ChanName::new("#tiny".to_string()))]
                 );
                 assert_eq!(servers[0].tls, true);
             }
@@ -246,9 +239,8 @@ mod tests {
 
     #[test]
     fn validation() {
-        // We trim the string fields when deserializing, so `validate` doesn't consider
-        // non-empty strings as empty even if they have only spaces, it assumes
-        // spaces should be trimmed
+        // We trim the string fields when deserializing, so `validate` doesn't consider non-empty
+        // strings as empty even if they have only spaces, it assumes spaces should be trimmed
         let config = Config {
             servers: vec![Server {
                 addr: "my_server".to_owned(),
@@ -286,24 +278,6 @@ mod tests {
         assert_eq!(
             &errors[3],
             "'realname' can't be empty, please update 'realname' field of 'my_server'"
-        );
-    }
-
-    #[test]
-    fn parse_chan_with_args() {
-        let config: Config = serde_yaml::from_str(
-            &get_default_config_yaml().replace("#tiny", "#tiny -ignore -notify off"),
-        )
-        .expect("parsed config");
-        assert_eq!(
-            config.servers[0].join,
-            vec![Chan {
-                name: ChanName::new("#tiny".to_string()),
-                config: TabConfig {
-                    ignore: Some(true),
-                    notifier: Some(Notifier::Off)
-                }
-            }]
         );
     }
 }

--- a/crates/tiny/src/conn.rs
+++ b/crates/tiny/src/conn.rs
@@ -545,37 +545,6 @@ fn handle_irc_msg(ui: &UI, client: &dyn Client, msg: wire::Msg) {
                     &format!("{} is away: {}", nick, msg),
                     &MsgTarget::User { serv, nick },
                 );
-            }
-            // ERR_BADCHANNAME
-            else if n == 479 && n_params > 2 {
-                let chan = &params[1];
-                let msg = &params[2];
-                ui.add_client_err_msg(
-                    &format!("Unable to join {}: {}", chan, msg),
-                    &MsgTarget::Chan {
-                        chan: ChanNameRef::new(chan),
-                        serv,
-                    },
-                );
-            }
-            // ERR_CHANNELISFULL    471
-            // ERR_INVITEONLYCHAN   473
-            // ERR_BANNEDFROMCHAN   474
-            // ERR_BADCHANNELKEY    475
-            // ERR_NEEDREGGEDNICK   477
-            // ERR_THROTTLE         480
-            else if (n == 471 || n == 473 || n == 474 || n == 475 || n == 477 || n == 480)
-                && n_params == 3
-            {
-                let chan = &params[1];
-                let msg = &params[2];
-                ui.add_client_err_msg(
-                    msg,
-                    &MsgTarget::Chan {
-                        chan: ChanNameRef::new(chan),
-                        serv,
-                    },
-                );
             } else {
                 match pfx {
                     Some(Server(msg_serv)) | Some(Ambiguous(msg_serv)) => {

--- a/crates/tiny/src/conn.rs
+++ b/crates/tiny/src/conn.rs
@@ -479,91 +479,117 @@ fn handle_irc_msg(ui: &UI, client: &dyn Client, msg: wire::Msg) {
             // Ignore
         }
 
+        // Solanum is used for OFTC and Libera
+        // https://github.com/solanum-ircd/solanum/blob/main/include/numeric.h
         Reply { num: n, params } => {
             let n_params = params.len();
-            if (
-                n <= 003 // RPL_WELCOME, RPL_YOURHOST, RPL_CREATED
-                    || n == 251 // RPL_LUSERCLIENT
-                    || n == 255 // RPL_LUSERME
-                    || n == 372 // RPL_MOTD
-                    || n == 375 // RPL_MOTDSTART
-                    || n == 376
-                // RPL_ENDOFMOTD
-            ) && n_params == 2
-            {
-                let msg = &params[1];
-                ui.add_msg(msg, time::now(), &MsgTarget::Server { serv });
-            } else if n == 4 // RPL_MYINFO
-                    || n == 5 // RPL_BOUNCE
-                    || (252..=254).contains(&n)
-            // RPL_LUSEROP, RPL_LUSERUNKNOWN, RPL_LUSERCHANNELS
-            {
-                let msg = params.into_iter().collect::<Vec<String>>().join(" ");
-                ui.add_msg(&msg, time::now(), &MsgTarget::Server { serv });
-            } else if (n == 265 || n == 266 || n == 250) && n_params > 0 {
-                let msg = &params[n_params - 1];
-                ui.add_msg(msg, time::now(), &MsgTarget::Server { serv });
-            }
-            // RPL_TOPIC
-            else if n == 332 && (n_params == 3 || n_params == 2) {
-                // RFC 2812 says this will have 2 arguments, but freenode sends 3 arguments (extra
-                // one being our nick).
-                let chan = &params[n_params - 2];
+            match (n, n_params) {
+                ( 000..=003 // RPL_WELCOME, RPL_YOURHOST, RPL_CREATED
+                | 251 // RPL_LUSERCLIENT
+                | 255 // RPL_LUSERME
+                | 372 // RPL_MOTD
+                | 375 // RPL_MOTDSTART
+                | 376 // RPL_ENDOFMOTD
+                , 2) => {
+                    let msg = &params[1];
+                    ui.add_msg(msg, time::now(), &MsgTarget::Server { serv });
+                }
+                ( 4 // RPL_MYINFO
+                | 5 // RPL_BOUNCE
+                | 252..=254  // RPL_LUSEROP, RPL_LUSERUNKNOWN, RPL_LUSERCHANNELS
+                , _) => {
+                    let msg = params.into_iter().collect::<Vec<String>>().join(" ");
+                    ui.add_msg(&msg, time::now(), &MsgTarget::Server { serv });
+                }
+                (250 | 265 | 266, n_params) if n_params > 0 => {
+                    let msg = &params[n_params - 1];
+                    ui.add_msg(msg, time::now(), &MsgTarget::Server { serv });
+                }
+                //RPL_TOPIC
+                (332, 3 | 2) => {
+                    // RFC 2812 says this will have 2 arguments, but freenode sends 3 arguments (extra
+                    // one being our nick).
+                    let chan = &params[n_params - 2];
                 let topic = &params[n_params - 1];
                 ui.set_topic(topic, time::now(), serv, ChanNameRef::new(chan));
-            }
-            // RPL_NAMREPLY: List of users in a channel
-            else if n == 353 && n_params > 3 {
-                let chan = &params[2];
-                let chan_target = MsgTarget::Chan {
-                    serv,
-                    chan: ChanNameRef::new(chan),
-                };
-
-                for nick in params[3].split_whitespace() {
-                    ui.add_nick(wire::drop_nick_prefix(nick), None, &chan_target);
                 }
-            }
-            // RPL_ENDOFNAMES: End of NAMES list
-            else if n == 366 {
-            }
-            // RPL_UNAWAY or RPL_NOWAWAY
-            else if (n == 305 || n == 306) && n_params > 1 {
-                let msg = &params[1];
-                ui.add_client_msg(msg, &MsgTarget::AllServTabs { serv });
-            }
-            // ERR_NOSUCHNICK
-            else if n == 401 && n_params > 2 {
-                let nick = &params[1];
-                let msg = &params[2];
-                ui.add_client_msg(msg, &MsgTarget::User { serv, nick });
-            // RPL_AWAY
-            } else if n == 301 && n_params > 2 {
-                let nick = &params[1];
-                let msg = &params[2];
-                ui.add_client_msg(
-                    &format!("{} is away: {}", nick, msg),
-                    &MsgTarget::User { serv, nick },
-                );
-            } else {
-                match pfx {
-                    Some(Server(msg_serv)) | Some(Ambiguous(msg_serv)) => {
-                        let msg_target = MsgTarget::Server { serv };
-                        ui.add_privmsg(
-                            &msg_serv,
-                            &params.join(" "),
-                            time::now(),
-                            &msg_target,
-                            false,
-                            false,
-                        );
-                        ui.set_tab_style(TabStyle::NewMsg, &msg_target);
+                // RPL_NAMREPLY: List of users in a channel
+                (353, 3) => {
+                    let chan = &params[2];
+                    let chan_target = MsgTarget::Chan {
+                        serv,
+                        chan: ChanNameRef::new(chan),
+                    };
+
+                    for nick in params[3].split_whitespace() {
+                        ui.add_nick(wire::drop_nick_prefix(nick), None, &chan_target);
                     }
-                    Some(User { .. }) | None => {
-                        debug!(
-                            "Ignoring numeric reply {}: pfx={:?}, params={:?}",
-                            n, pfx, params
-                        );
+                }
+                // RPL_ENDOFNAMES: End of NAMES list
+                (366, _) => {}
+                 // RPL_UNAWAY or RPL_NOWAWAY
+                (305 | 306, _) => {
+                    let msg = &params[1];
+                    ui.add_client_msg(msg, &MsgTarget::AllServTabs { serv });
+                }
+                // ERR_NOSUCHNICK
+                (401, 3) => {
+                    let nick = &params[1];
+                    let msg = &params[2];
+                    ui.add_client_msg(msg, &MsgTarget::User { serv, nick });
+                }
+                // RPL_AWAY
+                (301, 3) => {
+                    let nick = &params[1];
+                    let msg = &params[2];
+                    ui.add_client_msg(
+                        &format!("{} is away: {}", nick, msg),
+                        &MsgTarget::User { serv, nick },
+                    );
+                }
+                // ERR_BADCHANNAME
+                (479, 3)  => {
+                    let chan = &params[1];
+                    let msg = &params[2];
+                    ui.add_client_err_msg(
+                        &format!("Unable to join {}: {}", chan, msg),
+                        &MsgTarget::Chan { chan: ChanNameRef::new(chan), serv },
+                    );
+                }
+                // ERR_CHANNELISFULL    471
+                // ERR_INVITEONLYCHAN   473
+                // ERR_BANNEDFROMCHAN   474
+                // ERR_BADCHANNELKEY    475
+                // ERR_NEEDREGGEDNICK   477
+                // ERR_THROTTLE         480
+                (471 | 473 | 474 | 475 | 477 | 480, 3) => {
+                    let chan = &params[1];
+                    let msg = &params[2];
+                    ui.add_client_err_msg(
+                        msg,
+                        &MsgTarget::Chan { chan: ChanNameRef::new(chan), serv },
+                    );
+                }
+                _ => {
+                    match pfx {
+                        Some(Server(msg_serv)) | Some(Ambiguous(msg_serv)) => {
+                            let msg_target = MsgTarget::Server { serv };
+                            ui.add_privmsg(
+                                &msg_serv,
+                                &params.join(" "),
+                                time::now(),
+                                &msg_target,
+                                false,
+                                false,
+                            );
+                            ui.set_tab_style(TabStyle::NewMsg, &msg_target);
+                        }
+                        Some(User { .. }) | None => {
+                            debug!(
+                                "Ignoring numeric reply {}: pfx={:?}, params={:?}",
+                                n, pfx, params
+                            );
+                        }
                     }
                 }
             }

--- a/crates/tiny/src/main.rs
+++ b/crates/tiny/src/main.rs
@@ -152,7 +152,7 @@ fn run(
                 auto_join: server
                     .join
                     .iter()
-                    .map(|c| ChanNameRef::new(c).to_owned())
+                    .map(|c| ChanNameRef::new(c.name()).to_owned())
                     .collect(),
                 nickserv_ident: server.nickserv_ident,
                 sasl_auth: server.sasl_auth.map(|auth| libtiny_client::SASLAuth {

--- a/crates/tiny/src/main.rs
+++ b/crates/tiny/src/main.rs
@@ -12,7 +12,7 @@ mod utils;
 mod tests;
 
 use libtiny_client::{Client, ServerInfo};
-use libtiny_common::{ChanNameRef, MsgTarget};
+use libtiny_common::MsgTarget;
 use libtiny_logger::{Logger, LoggerInitError};
 use libtiny_tui::TUI;
 use ui::UI;
@@ -149,11 +149,7 @@ fn run(
                 pass: server.pass,
                 realname: server.realname,
                 nicks: server.nicks,
-                auto_join: server
-                    .join
-                    .iter()
-                    .map(|c| ChanNameRef::new(c.name()).to_owned())
-                    .collect(),
+                auto_join: server.join.iter().map(|c| c.name.to_owned()).collect(),
                 nickserv_ident: server.nickserv_ident,
                 sasl_auth: server.sasl_auth.map(|auth| libtiny_client::SASLAuth {
                     username: auth.username,

--- a/crates/tiny/src/main.rs
+++ b/crates/tiny/src/main.rs
@@ -149,7 +149,7 @@ fn run(
                 pass: server.pass,
                 realname: server.realname,
                 nicks: server.nicks,
-                auto_join: server.join.iter().map(|c| c.name.to_owned()).collect(),
+                auto_join: server.join.iter().map(|c| c.name().to_owned()).collect(),
                 nickserv_ident: server.nickserv_ident,
                 sasl_auth: server.sasl_auth.map(|auth| libtiny_client::SASLAuth {
                     username: auth.username,

--- a/crates/tiny/src/ui.rs
+++ b/crates/tiny/src/ui.rs
@@ -7,6 +7,7 @@ use libtiny_common::{ChanNameRef, MsgSource, MsgTarget, TabStyle};
 use libtiny_logger::Logger;
 use libtiny_tui::TUI;
 
+use libtiny_tui::config::TabConfig;
 use time::Tm;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -84,6 +85,7 @@ impl UI {
     delegate_ui!(clear_nicks(serv: &str,));
     delegate_ui!(set_nick(serv: &str, nick: &str,));
     delegate_ui!(set_tab_style(style: TabStyle, target: &MsgTarget,));
+    delegate_ui!(set_tab_config(config: TabConfig, target: &MsgTarget,));
     delegate_ui!(user_tab_exists(serv_name: &str, nick: &str,) -> bool);
 
     pub(crate) fn current_tab(&self) -> Option<MsgSource> {

--- a/crates/tiny/src/ui.rs
+++ b/crates/tiny/src/ui.rs
@@ -85,8 +85,13 @@ impl UI {
     delegate_ui!(clear_nicks(serv: &str,));
     delegate_ui!(set_nick(serv: &str, nick: &str,));
     delegate_ui!(set_tab_style(style: TabStyle, target: &MsgTarget,));
-    delegate_ui!(set_tab_config(config: TabConfig, target: &MsgTarget,));
     delegate_ui!(user_tab_exists(serv_name: &str, nick: &str,) -> bool);
+    delegate_ui!(get_tab_config(serv_name: &str, chan_name: Option<&ChanNameRef>,) -> TabConfig);
+    delegate_ui!(set_tab_config(
+        serv_name: &str,
+        chan_name: Option<&ChanNameRef>,
+        config: TabConfig,
+    ));
 
     pub(crate) fn current_tab(&self) -> Option<MsgSource> {
         self.ui.current_tab()


### PR DESCRIPTION
Added the ability to configure /ignore and /notify defaults for tabs.
The settings can be added under each chan, server or default section.

----

Overview:
- The most specific config will be the highest priority, i.e if you configure `ignore` under a chan then it will supersede the server's `ignore`, which will supersede the `ignore` under `defaults:`.

### Priority hierarchy (highest to lowest):
**Server tab:** server section -> defaults section -> hardcoded defaults (never ignore, notifier depends on conditional compilation, see `impl Default for Notifier`)
**Chan tabs:** chan section -> server section -> defaults section -> current setting on server tab (maybe someone toggled the setting manually)
**User tabs:** never ignore, notifier is always `Messages` (pre-existing behavior)

If acceptable, closes #118 
