### PR TITLE
TUI: Fix line heights on `/resize`

### DIFF
--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -74,9 +74,7 @@ impl MsgArea {
         self.lines_height = None;
 
         self.update_total_visible_lines();
-        if let Some(old_total_lines) = old_total_lines {
-            self.recalculate_scroll(old_height, old_total_lines);
-        }
+        self.recalculate_scroll(old_height, old_total_lines.unwrap());
     }
 
     pub(crate) fn layout(&self) -> Layout {

--- a/crates/libtiny_tui/src/msg_area/mod.rs
+++ b/crates/libtiny_tui/src/msg_area/mod.rs
@@ -74,7 +74,9 @@ impl MsgArea {
         self.lines_height = None;
 
         self.update_total_visible_lines();
-        self.recalculate_scroll(old_height, old_total_lines.unwrap());
+        if let Some(old_total_lines) = old_total_lines {
+            self.recalculate_scroll(old_height, old_total_lines);
+        }
     }
 
     pub(crate) fn layout(&self) -> Layout {
@@ -228,7 +230,7 @@ impl MsgArea {
     pub(crate) fn clear(&mut self) {
         self.lines.clear();
         self.scroll = 0;
-        self.lines_height = None;
+        self.lines_height = Some(0);
     }
 }
 


### PR DESCRIPTION
When you /clear the screen the total lines in the MsgArea gets cleared
and set to None. Then if you resize after that, we were unwrapping total
lines to recalculate the scroll amount and panicking.

We know the total line height is 0 after /clear so we now set total line
heights `Some(0)`.

Fixes #355