### PR TITLE
Introduce ServerId type, use it in MsgSource and MsgTarget

### DIFF
--- a/crates/libtiny_tui/examples/text.rs
+++ b/crates/libtiny_tui/examples/text.rs
@@ -17,10 +17,15 @@ fn main() {
 
     let local = tokio::task::LocalSet::new();
 
-    let tab = MsgTarget::Server { serv: "mentions" };
-
     local.block_on(&runtime, async move {
         let (tui, rcv_ev) = TUI::run(PathBuf::from("../tiny/config.yml"));
+
+        let serv_id = tui.mentions_serv_id();
+
+        let tab = MsgTarget::Server {
+            serv_id,
+            serv: "mentions",
+        };
 
         let mut text = String::new();
         let mut file = File::open("test/lipsum.txt").unwrap();

--- a/crates/libtiny_tui/src/tests/layout.rs
+++ b/crates/libtiny_tui/src/tests/layout.rs
@@ -11,13 +11,17 @@ fn test_join_part_overflow() {
     let mut tui = TUI::new_test(21, 4);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
     tui.add_nick("123456", Some(ts), &target);
     tui.add_nick("abcdef", Some(ts), &target);
@@ -40,13 +44,17 @@ fn test_alignment_long_string() {
     tui.set_layout(Layout::Aligned { max_nick_len: 12 });
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
     tui.add_privmsg(
         "osa1",
@@ -72,10 +80,14 @@ fn test_alignment_long_string() {
 #[test]
 fn test_mnemonic_generation() {
     let mut tui = TUI::new_test(10, 10);
-    tui.new_chan_tab("s1", ChanNameRef::new("#ab"));
-    tui.new_chan_tab("s2", ChanNameRef::new("#ab"));
-    tui.new_chan_tab("s3", ChanNameRef::new("#ab"));
-    tui.new_chan_tab("s4", ChanNameRef::new("#ab"));
+    let (s1, _) = tui.new_server_tab("s1", None);
+    tui.new_chan_tab(s1, "s1", ChanNameRef::new("#ab"));
+    let (s2, _) = tui.new_server_tab("s2", None);
+    tui.new_chan_tab(s2, "s2", ChanNameRef::new("#ab"));
+    let (s3, _) = tui.new_server_tab("s3", None);
+    tui.new_chan_tab(s3, "s3", ChanNameRef::new("#ab"));
+    let (s4, _) = tui.new_server_tab("s4", None);
+    tui.new_chan_tab(s4, "s4", ChanNameRef::new("#ab"));
     let tabs = tui.get_tabs();
     assert_eq!(tabs.len(), 9); // mentions, 4 servers, 4 channels
     assert_eq!(tabs[2].switch, Some('a'));

--- a/crates/libtiny_tui/src/tests/mod.rs
+++ b/crates/libtiny_tui/src/tests/mod.rs
@@ -33,8 +33,8 @@ fn init_screen() {
 fn close_rightmost_tab() {
     // After closing right-most tab the tab bar should scroll left.
     let mut tui = TUI::new_test(20, 4);
-    tui.new_server_tab("irc.server_1.org", None);
-    tui.new_server_tab("irc.server_2.org", None);
+    let (serv1_id, _) = tui.new_server_tab("irc.server_1.org", None);
+    let (serv2_id, _) = tui.new_server_tab("irc.server_2.org", None);
     tui.next_tab();
     tui.next_tab();
     tui.draw();
@@ -49,7 +49,7 @@ fn close_rightmost_tab() {
 
     // Should scroll left when the server tab is closed. Left arrow should still be visible as
     // there are still tabs to the left.
-    tui.close_server_tab("irc.server_2.org");
+    tui.close_server_tab(serv2_id);
     tui.draw();
 
     #[rustfmt::skip]
@@ -61,7 +61,7 @@ fn close_rightmost_tab() {
     expect_screen(screen, &tui.get_front_buffer(), 20, 4, Location::caller());
 
     // Scroll left again, left arrow should disappear this time.
-    tui.close_server_tab("irc.server_1.org");
+    tui.close_server_tab(serv1_id);
     tui.draw();
 
     #[rustfmt::skip]
@@ -78,13 +78,17 @@ fn small_screen_1() {
     let mut tui = TUI::new_test(21, 3);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
     tui.add_nick("123456", Some(ts), &target);
     tui.add_nick("abcdef", Some(ts), &target);
@@ -127,15 +131,19 @@ fn small_screen_2() {
     let mut tui = TUI::new_test(21, 4);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
-    tui.set_topic("Blah blah blah-", ts.clone(), serv, chan);
+    tui.set_topic("Blah blah blah-", ts.clone(), serv_id, serv, chan);
 
     tui.draw();
 
@@ -164,9 +172,9 @@ fn ctrl_w() {
     let mut tui = TUI::new_test(30, 3);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
@@ -233,8 +241,8 @@ fn test_text_field_wrap() {
     let mut tui = TUI::new_test(40, 8);
 
     let server = "chat.freenode.net";
-    tui.new_server_tab(server, None);
-    tui.set_nick(server, "x");
+    let (serv_id, _) = tui.new_server_tab(server, None);
+    tui.set_nick(serv_id, server, "x");
 
     // Switch to server tab
     tui.next_tab();

--- a/crates/libtiny_tui/src/tests/resize.rs
+++ b/crates/libtiny_tui/src/tests/resize.rs
@@ -13,13 +13,17 @@ fn test_resize_recalc_scroll() {
     let mut tui = TUI::new_test(15, 5);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
     tui.add_privmsg(
         "osa1",
@@ -86,13 +90,17 @@ fn test_resize_scroll_stick_to_top() {
     let mut tui = TUI::new_test(18, 10);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
 
     for i in 0..15 {
@@ -148,13 +156,17 @@ fn test_resize_no_scroll_stay_on_bottom() {
     let mut tui = TUI::new_test(18, 10);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
 
     for i in 0..15 {
@@ -252,13 +264,17 @@ fn test_resize_scroll_resize() {
     let mut tui = TUI::new_test(16, 10);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
 
     for i in 0..15 {
@@ -322,13 +338,17 @@ fn test_clear_resize_recalc_scroll() {
     let mut tui = TUI::new_test(15, 5);
     let serv = "irc.server_1.org";
     let chan = ChanNameRef::new("#chan");
-    tui.new_server_tab(serv, None);
-    tui.set_nick(serv, "osa1");
-    tui.new_chan_tab(serv, chan);
+    let (serv_id, _) = tui.new_server_tab(serv, None);
+    tui.set_nick(serv_id, serv, "osa1");
+    tui.new_chan_tab(serv_id, serv, chan);
     tui.next_tab();
     tui.next_tab();
 
-    let target = MsgTarget::Chan { serv, chan };
+    let target = MsgTarget::Chan {
+        serv_id,
+        serv,
+        chan,
+    };
     let ts = time::at_utc(time::Timespec::new(0, 0));
     for _ in 0..6 {
         tui.add_privmsg("osa1", &"1111 ".repeat(3), ts, &target, false, false);

--- a/crates/tiny/src/main.rs
+++ b/crates/tiny/src/main.rs
@@ -104,6 +104,7 @@ fn run(
     local.block_on(&runtime, async move {
         // Create TUI task
         let (tui, rcv_tui_ev) = TUI::run(config_path.clone());
+        let mentions_serv_id = tui.mentions_serv_id();
         tui.draw();
 
         // Create logger
@@ -113,7 +114,10 @@ fn run(
                 // Somehwat hacky -- only tab we have is "mentions" so we show the error there
                 tui_clone.add_client_err_msg(
                     &format!("Logger error: {}", err),
-                    &MsgTarget::Server { serv: "mentions" },
+                    &MsgTarget::Server {
+                        serv_id: mentions_serv_id,
+                        serv: "mentions",
+                    },
                 )
             })
         };
@@ -122,7 +126,10 @@ fn run(
                 Err(LoggerInitError::CouldNotCreateDir { dir_path, err }) => {
                     tui.add_client_err_msg(
                         &format!("Could not create log directory {:?}: {}", dir_path, err),
-                        &MsgTarget::Server { serv: "mentions" },
+                        &MsgTarget::Server {
+                            serv_id: mentions_serv_id,
+                            serv: "mentions",
+                        },
                     );
                     tui.draw();
                     None

--- a/crates/tiny/src/ui.rs
+++ b/crates/tiny/src/ui.rs
@@ -209,17 +209,34 @@ pub(crate) fn send_msg(
                 return;
             }
 
-            MsgSource::Chan { ref serv, ref chan } => {
-                (MsgTarget::Chan { serv, chan }, chan.display())
-            }
+            MsgSource::Chan {
+                serv_id,
+                serv,
+                chan,
+            } => (
+                MsgTarget::Chan {
+                    serv_id,
+                    serv,
+                    chan,
+                },
+                chan.display(),
+            ),
 
-            MsgSource::User { ref serv, ref nick } => {
+            MsgSource::User {
+                serv_id,
+                serv,
+                nick,
+            } => {
                 let msg_target = if nick.eq_ignore_ascii_case("nickserv")
                     || nick.eq_ignore_ascii_case("chanserv")
                 {
-                    MsgTarget::Server { serv }
+                    MsgTarget::Server { serv_id, serv }
                 } else {
-                    MsgTarget::User { serv, nick }
+                    MsgTarget::User {
+                        serv_id,
+                        serv,
+                        nick,
+                    }
                 };
                 (msg_target, nick)
             }


### PR DESCRIPTION
This will allow connecting to same server multiple times, fixing #374.

I implemented the plan as described in https://github.com/osa1/tiny/issues/374#issuecomment-1014406721.

This currently does not build -- I need to update the logger crate. I'm not sure how to handle multiple servers with same name and same alias in the logger yet. It's probably best to reject such cases and ask the user to come up with a unique `server name, alias` pair.

In principle, once we establish the invariant that `server name, alias` pairs are always unique, we no longer need the `ServerId` type. In practice though it's easier (and more efficient) to compare integers (`ServerId`) than string pairs.

So maybe it's best to make sure `(server name, alias)` are unique (for to logger, TUI doesn't care), but keep the `ServerId` type.