### PR TITLE
Move cargo release configuration to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   make_release:
     name: Make release
     runs-on: ubuntu-20.04
+    env:
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+      CARGO_PROFILE_RELEASE_LTO: fat
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,3 @@ members = [
     "crates/termbox",
     "crates/tiny",
 ]
-
-[profile.release]
-lto = true
-codegen-units = 1


### PR DESCRIPTION
By setting these in Cargo.toml everyone is forced to build with them. It
is better to leave the defaults to Cargo and the user building the
project. If there are important gains in binary size or speed  with
these options they can continue to be set for the official builds as
performed by CI.