### PR TITLE
Fix new lints and warnings

### DIFF
--- a/crates/libtiny_client/src/state.rs
+++ b/crates/libtiny_client/src/state.rs
@@ -480,7 +480,7 @@ impl StateInner {
                         {
                             i += 1;
                         }
-                        let usermask = (&param[i..]).trim();
+                        let usermask = param[i..].trim();
                         self.usermask = Some(usermask.to_owned());
                     }
                 }
@@ -746,7 +746,7 @@ fn parse_yourhost_msg(params: &[String]) -> Option<String> {
     if msg.len() >= SERVERNAME_PREFIX_LEN && &msg[..SERVERNAME_PREFIX_LEN] == SERVERNAME_PREFIX {
         let slice1 = &msg[SERVERNAME_PREFIX_LEN..];
         let servername_ends = slice1.find('[').or_else(|| slice1.find(','))?;
-        Some((&slice1[..servername_ends]).to_owned())
+        Some(slice1[..servername_ends].to_owned())
     } else {
         None
     }

--- a/crates/libtiny_client/src/stream.rs
+++ b/crates/libtiny_client/src/stream.rs
@@ -81,8 +81,6 @@ impl Stream {
 
     #[cfg(feature = "tls-rustls")]
     pub(crate) async fn new_tls(addr: SocketAddr, host_name: &str) -> Result<Stream, StreamError> {
-        use std::convert::TryFrom;
-
         let tcp_stream = TcpStream::connect(addr).await?;
         let name = tokio_rustls::rustls::ServerName::try_from(host_name)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;

--- a/crates/libtiny_common/src/lib.rs
+++ b/crates/libtiny_common/src/lib.rs
@@ -29,7 +29,7 @@ impl AsRef<ChanNameRef> for ChanName {
     }
 }
 
-impl<'a> Borrow<ChanNameRef> for ChanName {
+impl Borrow<ChanNameRef> for ChanName {
     fn borrow(&self) -> &ChanNameRef {
         self.as_ref()
     }

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -179,7 +179,7 @@ async fn input_handler<S>(
                     TUIRet::Input { msg, from } => {
                         if msg[0] == '/' {
                             // Handle TUI commands, send others to downstream
-                            let cmd: String = (&msg[1..]).iter().collect();
+                            let cmd: String = msg[1..].iter().collect();
                             let result = tui.borrow_mut().try_handle_cmd(&cmd, &from);
                             match result {
                                 CmdResult::Ok => {}

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -844,7 +844,7 @@ impl TUI {
                 width_left -= 2;
             }
             // drop any tabs that overflows from the screen
-            for (tab_idx, tab) in (&self.tabs[i..]).iter().enumerate() {
+            for (tab_idx, tab) in self.tabs[i..].iter().enumerate() {
                 if tab.width() > width_left {
                     break;
                 } else {
@@ -894,7 +894,7 @@ impl TUI {
         // debug!("left_arr: {}, right_arr: {}", left_arr, right_arr);
 
         // finally draw the tabs
-        for (tab_idx, tab) in (&self.tabs[tab_left..tab_right]).iter().enumerate() {
+        for (tab_idx, tab) in self.tabs[tab_left..tab_right].iter().enumerate() {
             tab.draw(
                 &mut self.tb,
                 &self.colors,

--- a/crates/libtiny_wire/src/formatting.rs
+++ b/crates/libtiny_wire/src/formatting.rs
@@ -372,7 +372,7 @@ impl<'a> Iterator for FormatEventParser<'a> {
     }
 }
 
-pub fn parse_irc_formatting<'a>(s: &'a str) -> impl Iterator<Item = IrcFormatEvent> + 'a {
+pub fn parse_irc_formatting(s: &str) -> impl Iterator<Item = IrcFormatEvent> {
     FormatEventParser::new(s)
 }
 

--- a/crates/libtiny_wire/src/lib.rs
+++ b/crates/libtiny_wire/src/lib.rs
@@ -150,8 +150,8 @@ impl Pfx {
 fn parse_pfx(pfx: &str) -> Pfx {
     match pfx.find(&['!', '@'][..]) {
         Some(idx) => Pfx::User {
-            nick: (&pfx[0..idx]).to_owned(),
-            user: (&pfx[idx + 1..]).to_owned(),
+            nick: pfx[0..idx].to_owned(),
+            user: pfx[idx + 1..].to_owned(),
         },
         None => {
             // Chars that nicks can have but servernames cannot

--- a/crates/term_input/src/lib.rs
+++ b/crates/term_input/src/lib.rs
@@ -296,7 +296,7 @@ impl Stream for Input {
     type Item = std::io::Result<Event>;
 
     fn poll_next(mut self: Pin<&mut Input>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let self_: &mut Input = &mut *self;
+        let self_: &mut Input = &mut self;
 
         'main: loop {
             // Try to parse any bytes in the input buffer from the last poll

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -86,7 +86,7 @@ fn find_client_idx(clients: &[Client], serv_name: &str) -> Option<usize> {
     None
 }
 
-fn find_client<'a>(clients: &'a mut Vec<Client>, serv_name: &str) -> Option<&'a mut Client> {
+fn find_client<'a>(clients: &'a mut [Client], serv_name: &str) -> Option<&'a mut Client> {
     match find_client_idx(clients, serv_name) {
         None => None,
         Some(idx) => Some(&mut clients[idx]),
@@ -193,7 +193,7 @@ fn connect(args: CmdArgs) {
     }
 }
 
-fn reconnect(ui: &UI, clients: &mut Vec<Client>, src: MsgSource) {
+fn reconnect(ui: &UI, clients: &mut [Client], src: MsgSource) {
     if let Some(client) = find_client(clients, src.serv_name()) {
         ui.add_client_msg(
             "Reconnecting...",


### PR DESCRIPTION
Fixes lints and warnings generated by rustc 1.65.0.

---

Creating a CL to test all targets.