### PR TITLE
Allow `/quit` with a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Commands start with `/` character.
   Running this command in a server tab applies it to all channels of that
   server. You can check your notify state in the status line.
 
-- `/quit`: Quit
+- `/quit`: Quit. You can use `/quit <reason>` to send a goodbye message.
 
 ## Server commands
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Commands start with `/` character.
 - `/join <channel>`: Join to a channel
 
 - `/close`: Close the current tab. Leaves the channel if the current tab is a
-  channel. Leaves the server if the tab is a server.
+  channel. Leaves the server if the tab is a server. You can use `/close <reason>` to send a goodbye message.
 
 - `/connect <hostname>:<port>`: Connect to a server. Uses `defaults` in the
   config file for nick, realname, hostname and auto cmds.

--- a/crates/libtiny_client/src/lib.rs
+++ b/crates/libtiny_client/src/lib.rs
@@ -222,8 +222,8 @@ impl Client {
     }
 
     /// Leave a channel.
-    pub fn part(&mut self, chan: &ChanNameRef) {
-        self.state.leave_channel(&mut self.msg_chan, chan)
+    pub fn part(&mut self, chan: &ChanNameRef, reason: Option<String>) {
+        self.state.leave_channel(&mut self.msg_chan, chan, reason)
     }
 
     /// Set away status. `None` means not away.

--- a/crates/libtiny_client/src/state.rs
+++ b/crates/libtiny_client/src/state.rs
@@ -70,8 +70,15 @@ impl State {
         self.inner.borrow().get_chan_nicks(chan)
     }
 
-    pub(crate) fn leave_channel(&self, msg_chan: &mut Sender<Cmd>, chan: &ChanNameRef, reason: Option<String>) {
-        self.inner.borrow_mut().leave_channel(msg_chan, chan, reason)
+    pub(crate) fn leave_channel(
+        &self,
+        msg_chan: &mut Sender<Cmd>,
+        chan: &ChanNameRef,
+        reason: Option<String>,
+    ) {
+        self.inner
+            .borrow_mut()
+            .leave_channel(msg_chan, chan, reason)
     }
 
     pub(crate) fn kill_join_tasks(&self) {
@@ -687,7 +694,12 @@ impl StateInner {
     }
 
     /// If channel is in Joining state cancel Joining task, otherwise sent part message
-    fn leave_channel(&mut self, msg_chan: &mut Sender<Cmd>, chan: &ChanNameRef, reason: Option<String>) {
+    fn leave_channel(
+        &mut self,
+        msg_chan: &mut Sender<Cmd>,
+        chan: &ChanNameRef,
+        reason: Option<String>,
+    ) {
         if let Some(idx) = utils::find_idx(&self.chans, |c| c.name == *chan) {
             match &mut self.chans[idx].join_state {
                 JoinState::NotJoined => {}
@@ -695,7 +707,9 @@ impl StateInner {
                     debug!("Aborting task to retry joining {}", chan.display());
                     let _ = stop_task.try_send(());
                 }
-                JoinState::Joined => msg_chan.try_send(Cmd::Msg(wire::part(chan, reason))).unwrap(),
+                JoinState::Joined => msg_chan
+                    .try_send(Cmd::Msg(wire::part(chan, reason)))
+                    .unwrap(),
             }
         }
     }

--- a/crates/libtiny_client/src/state.rs
+++ b/crates/libtiny_client/src/state.rs
@@ -70,8 +70,8 @@ impl State {
         self.inner.borrow().get_chan_nicks(chan)
     }
 
-    pub(crate) fn leave_channel(&self, msg_chan: &mut Sender<Cmd>, chan: &ChanNameRef) {
-        self.inner.borrow_mut().leave_channel(msg_chan, chan)
+    pub(crate) fn leave_channel(&self, msg_chan: &mut Sender<Cmd>, chan: &ChanNameRef, reason: Option<String>) {
+        self.inner.borrow_mut().leave_channel(msg_chan, chan, reason)
     }
 
     pub(crate) fn kill_join_tasks(&self) {
@@ -687,7 +687,7 @@ impl StateInner {
     }
 
     /// If channel is in Joining state cancel Joining task, otherwise sent part message
-    fn leave_channel(&mut self, msg_chan: &mut Sender<Cmd>, chan: &ChanNameRef) {
+    fn leave_channel(&mut self, msg_chan: &mut Sender<Cmd>, chan: &ChanNameRef, reason: Option<String>) {
         if let Some(idx) = utils::find_idx(&self.chans, |c| c.name == *chan) {
             match &mut self.chans[idx].join_state {
                 JoinState::NotJoined => {}
@@ -695,7 +695,7 @@ impl StateInner {
                     debug!("Aborting task to retry joining {}", chan.display());
                     let _ = stop_task.try_send(());
                 }
-                JoinState::Joined => msg_chan.try_send(Cmd::Msg(wire::part(chan))).unwrap(),
+                JoinState::Joined => msg_chan.try_send(Cmd::Msg(wire::part(chan, reason))).unwrap(),
             }
         }
     }

--- a/crates/libtiny_common/src/lib.rs
+++ b/crates/libtiny_common/src/lib.rs
@@ -212,7 +212,9 @@ pub enum TabStyle {
 /// UI events
 #[derive(Debug)]
 pub enum Event {
-    Abort,
+    Abort {
+        msg: Option<String>,
+    },
     Msg {
         msg: String,
         source: MsgSource,

--- a/crates/libtiny_tui/examples/chat.rs
+++ b/crates/libtiny_tui/examples/chat.rs
@@ -96,7 +96,7 @@ fn handle_input_ev(ui: &TUI, ev: Event, abort: &mut mpsc::Sender<()>) {
                 ui.set_nick(SERV, new_nick);
             }
         }
-        Abort => {
+        Abort { .. } => {
             abort.try_send(()).unwrap();
         }
         Msg { .. } | Lines { .. } => {}

--- a/crates/libtiny_tui/examples/tabs.rs
+++ b/crates/libtiny_tui/examples/tabs.rs
@@ -79,6 +79,6 @@ fn handle_input_ev(ui: &TUI, ev: Event) {
                 }
             }
         }
-        Abort | Msg { .. } | Lines { .. } => {}
+        Abort { .. } | Msg { .. } | Lines { .. } => {}
     }
 }

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -171,7 +171,7 @@ async fn input_handler<S>(
                 let tui_ret = tui.borrow_mut().handle_input_event(ev, &mut rcv_editor_ret);
                 match tui_ret {
                     TUIRet::Abort => {
-                        snd_ev.try_send(Event::Abort).unwrap();
+                        snd_ev.try_send(Event::Abort { msg: None }).unwrap();
                         let _ = snd_abort.try_send(());
                         return;
                     }
@@ -187,7 +187,7 @@ async fn input_handler<S>(
                                     snd_ev.try_send(Event::Cmd { cmd, source: from }).unwrap()
                                 }
                                 CmdResult::Quit => {
-                                    snd_ev.try_send(Event::Abort).unwrap();
+                                    snd_ev.try_send(Event::Abort { msg: None }).unwrap();
                                     let _ = snd_abort.try_send(());
                                     return;
                                 }

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -186,8 +186,8 @@ async fn input_handler<S>(
                                 CmdResult::Continue => {
                                     snd_ev.try_send(Event::Cmd { cmd, source: from }).unwrap()
                                 }
-                                CmdResult::Quit => {
-                                    snd_ev.try_send(Event::Abort { msg: None }).unwrap();
+                                CmdResult::Quit(msg) => {
+                                    snd_ev.try_send(Event::Abort { msg }).unwrap();
                                     let _ = snd_abort.try_send(());
                                     return;
                                 }

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -107,8 +107,8 @@ pub(crate) enum CmdResult {
     Ok,
     /// Pass command through to cmd.rs for further handling
     Continue,
-    /// Quit command was executed
-    Quit,
+    /// Quit command was executed, with the payload as a quit message
+    Quit(Option<String>),
 }
 
 impl TUI {
@@ -299,7 +299,21 @@ impl TUI {
                 // Fall through to print help for cmd.rs commands
                 CmdResult::Continue
             }
-            Some("quit") => CmdResult::Quit,
+            Some("quit") => {
+                // Cut the "quit " part of the command
+                // (the slash is already cut outside this function),
+                // and use the rest as the message for the /quit,
+                // including other (potentially consecutive) spaces.
+                // `&cmd[("quit ".len())..]` would freeze the program
+                // if the command given has nothing more besides "/quit".
+                let reason: String = cmd.chars().skip(5 /* "quit ".len() */).collect();
+
+                if reason.is_empty() {
+                    CmdResult::Quit(None)
+                } else {
+                    CmdResult::Quit(Some(reason))
+                }
+            }
             _ => CmdResult::Continue,
         }
     }

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -300,13 +300,8 @@ impl TUI {
                 CmdResult::Continue
             }
             Some("quit") => {
-                // Cut the "quit " part of the command
-                // (the slash is already cut outside this function),
-                // and use the rest as the message for the /quit,
-                // including other (potentially consecutive) spaces.
-                // `&cmd[("quit ".len())..]` would freeze the program
-                // if the command given has nothing more besides "/quit".
-                let reason: String = cmd.chars().skip(5 /* "quit ".len() */).collect();
+                // Note: `SplitWhitespace::as_str` could be used here instead, when it gets stabilized.
+                let reason: String = cmd.chars().skip("quit ".len()).collect();
 
                 if reason.is_empty() {
                     CmdResult::Quit(None)

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -61,7 +61,7 @@ impl CmdUsage {
     }
 }
 
-const QUIT_CMD: CmdUsage = CmdUsage::new("quit", "Quit tiny", "`/quit`");
+const QUIT_CMD: CmdUsage = CmdUsage::new("quit", "Quit tiny", "`/quit` or `/quit <reason>`");
 const CLEAR_CMD: CmdUsage = CmdUsage::new("clear", "Clears current tab", "`/clear`");
 const IGNORE_CMD: CmdUsage = CmdUsage::new("ignore", "Ignore join/quit messages", "`/ignore`");
 const NOTIFY_CMD: CmdUsage = CmdUsage::new(

--- a/crates/libtiny_wire/src/lib.rs
+++ b/crates/libtiny_wire/src/lib.rs
@@ -47,8 +47,12 @@ where
     format!("JOIN {}\r\n", chans.join(","))
 }
 
-pub fn part(chan: &ChanNameRef) -> String {
-    format!("PART {}\r\n", chan.display())
+pub fn part(chan: &ChanNameRef, reason: Option<String>) -> String {
+    match reason {
+        None => format!("PART {}\r\n", chan.display()),
+        Some(reason) => format!("PART {} {}\r\n", chan.display(), reason)
+    }
+    
 }
 
 pub fn privmsg(msgtarget: &str, msg: &str) -> String {

--- a/crates/libtiny_wire/src/lib.rs
+++ b/crates/libtiny_wire/src/lib.rs
@@ -50,9 +50,8 @@ where
 pub fn part(chan: &ChanNameRef, reason: Option<String>) -> String {
     match reason {
         None => format!("PART {}\r\n", chan.display()),
-        Some(reason) => format!("PART {} {}\r\n", chan.display(), reason)
+        Some(reason) => format!("PART {} {}\r\n", chan.display(), reason),
     }
-    
 }
 
 pub fn privmsg(msgtarget: &str, msg: &str) -> String {

--- a/crates/libtiny_wire/src/lib.rs
+++ b/crates/libtiny_wire/src/lib.rs
@@ -50,7 +50,7 @@ where
 pub fn part(chan: &ChanNameRef, reason: Option<String>) -> String {
     match reason {
         None => format!("PART {}\r\n", chan.display()),
-        Some(reason) => format!("PART {} {}\r\n", chan.display(), reason),
+        Some(reason) => format!("PART {} :{}\r\n", chan.display(), reason),
     }
 }
 

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -138,7 +138,7 @@ static CLOSE_CMD: Cmd = Cmd {
 
 fn close(args: CmdArgs) {
     let CmdArgs {
-        ui, clients, src, ..
+        args, ui, clients, src, ..
     } = args;
     match src {
         MsgSource::Serv { ref serv } if serv == "mentions" => {
@@ -149,7 +149,11 @@ fn close(args: CmdArgs) {
             let client_idx = find_client_idx(clients, &serv).unwrap();
             // TODO: this probably won't close the connection?
             let mut client = clients.remove(client_idx);
-            client.quit(None);
+            if args.is_empty() {
+                client.quit(None);
+            } else {
+                client.quit(Some(args.to_string()));
+            }
         }
         MsgSource::Chan { serv, chan } => {
             ui.close_chan_tab(&serv, chan.borrow());

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -158,7 +158,11 @@ fn close(args: CmdArgs) {
         MsgSource::Chan { serv, chan } => {
             ui.close_chan_tab(&serv, chan.borrow());
             let client_idx = find_client_idx(clients, &serv).unwrap();
-            clients[client_idx].part(&chan);
+            if args.is_empty() {
+                clients[client_idx].part(&chan, None);
+            } else {
+                clients[client_idx].part(&chan, Some(args.to_string()));
+            }
         }
         MsgSource::User { serv, nick } => {
             ui.close_user_tab(&serv, &nick);

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -138,7 +138,11 @@ static CLOSE_CMD: Cmd = Cmd {
 
 fn close(args: CmdArgs) {
     let CmdArgs {
-        args, ui, clients, src, ..
+        args,
+        ui,
+        clients,
+        src,
+        ..
     } = args;
     match src {
         MsgSource::Serv { ref serv } if serv == "mentions" => {

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -133,7 +133,7 @@ static CLOSE_CMD: Cmd = Cmd {
     name: "close",
     cmd_fn: close,
     description: "Closes current tab",
-    usage: "`/close`",
+    usage: "`/close` or `/close <reason>`",
 };
 
 fn close(args: CmdArgs) {

--- a/crates/tiny/src/ui.rs
+++ b/crates/tiny/src/ui.rs
@@ -112,9 +112,9 @@ fn handle_input_ev(
 ) {
     use libtiny_common::Event::*;
     match ev {
-        Abort => {
+        Abort { msg } => {
             for client in clients {
-                client.quit(None);
+                client.quit(msg.clone());
             }
         }
         Msg { msg, source } => {


### PR DESCRIPTION
This pull request adds an optional message parameter to the `/quit` command to be sent to the connected servers as a reason for leaving.

This pull request was tested by using a tiny and a HexChat client, both connected to the same server.

Fixes #365.