### PR TITLE
add formatting to termbox, render in tui (#364)

### DIFF
--- a/crates/libtiny_tui/src/msg_area/line.rs
+++ b/crates/libtiny_tui/src/msg_area/line.rs
@@ -109,14 +109,29 @@ impl Line {
         }
     }
 
+    fn add_attr(&mut self, attr: u16) {
+        if let SegStyle::Fixed(style) = self.current_seg.style {
+            self.set_message_style(SegStyle::Fixed(Style {
+                fg: style.fg | attr,
+                bg: style.bg,
+            }))
+        } else {
+            let style = SegStyle::Fixed(Style {
+                fg: termbox_simple::TB_DEFAULT | attr,
+                bg: termbox_simple::TB_DEFAULT,
+            });
+            self.set_message_style(style)
+        }
+    }
+
     fn add_text_inner(&mut self, str: &str) {
         for format_event in parse_irc_formatting(str) {
             match format_event {
-                IrcFormatEvent::Bold
-                | IrcFormatEvent::Italic
-                | IrcFormatEvent::Underline
-                | IrcFormatEvent::Strikethrough
-                | IrcFormatEvent::Monospace => {
+                IrcFormatEvent::Bold => self.add_attr(termbox_simple::TB_BOLD),
+                IrcFormatEvent::Italic => self.add_attr(termbox_simple::TB_ITALIC),
+                IrcFormatEvent::Underline => self.add_attr(termbox_simple::TB_UNDERLINE),
+                IrcFormatEvent::Strikethrough => self.add_attr(termbox_simple::TB_STRIKETHROUGH),
+                IrcFormatEvent::Monospace => {
                     // TODO
                 }
                 IrcFormatEvent::Text(text) => {

--- a/crates/termbox/src/lib.rs
+++ b/crates/termbox/src/lib.rs
@@ -18,6 +18,8 @@ use unicode_width::UnicodeWidthChar;
 pub const TB_DEFAULT: u16 = 0x0000;
 pub const TB_BOLD: u16 = 0x0100;
 pub const TB_UNDERLINE: u16 = 0x0200;
+pub const TB_ITALIC: u16 = 0x0400;
+pub const TB_STRIKETHROUGH: u16 = 0x0800;
 
 pub struct Termbox {
     // Not available in test instances
@@ -396,6 +398,8 @@ impl Termbox {
 
         let bold = fg & TB_BOLD != 0;
         let underline = fg & TB_UNDERLINE != 0;
+        let italic = fg & TB_ITALIC != 0;
+        let strikethrough = fg & TB_STRIKETHROUGH != 0;
 
         self.last_fg = fg;
         self.last_bg = bg;
@@ -414,6 +418,16 @@ impl Termbox {
         if bold {
             self.output_buffer
                 .extend_from_slice(termion::style::Bold.as_ref());
+        }
+
+        if italic {
+            self.output_buffer
+                .extend_from_slice(termion::style::Italic.as_ref());
+        }
+
+        if strikethrough {
+            self.output_buffer
+                .extend_from_slice(termion::style::CrossedOut.as_ref());
         }
 
         if fg != 0 {


### PR DESCRIPTION
added a fn for Line that updates its current style, OR'ing it with the attribute you want to set.

Had to add a few more bitmasks for Italic and Strikethrough as well.

This setup allows attributes to 'stack' easily, ie: receiving a message that's both bold and italic will show properly.

<img width="295" alt="image" src="https://user-images.githubusercontent.com/101823296/213013751-78d81ac8-7fe3-4069-9e78-a6381fe24a23.png">
