### PR TITLE
Support tiny commands in keymap config

### DIFF
--- a/crates/libtiny_tui/src/exit_dialogue.rs
+++ b/crates/libtiny_tui/src/exit_dialogue.rs
@@ -48,7 +48,7 @@ impl ExitDialogue {
         }
     }
 
-    pub(crate) fn keypressed(&self, key_action: KeyAction) -> WidgetRet {
+    pub(crate) fn keypressed(&self, key_action: &KeyAction) -> WidgetRet {
         match key_action {
             KeyAction::Input('y') | KeyAction::InputSend => WidgetRet::Abort,
             _ => WidgetRet::Remove,

--- a/crates/libtiny_tui/src/input_area/mod.rs
+++ b/crates/libtiny_tui/src/input_area/mod.rs
@@ -334,9 +334,7 @@ impl InputArea {
                 self.inc_cursor();
                 WidgetRet::KeyHandled
             }
-            KeyAction::RunIrcCommand(cmd) => {
-                WidgetRet::Command(cmd.to_owned())
-            }
+            KeyAction::RunIrcCommand(cmd) => WidgetRet::Command(cmd.to_owned()),
             _ => WidgetRet::KeyIgnored,
         }
     }

--- a/crates/libtiny_tui/src/input_area/mod.rs
+++ b/crates/libtiny_tui/src/input_area/mod.rs
@@ -334,7 +334,7 @@ impl InputArea {
                 self.inc_cursor();
                 WidgetRet::KeyHandled
             }
-            KeyAction::RunIrcCommand(cmd) => WidgetRet::Command(cmd.to_owned()),
+            KeyAction::RunCommand(cmd) => WidgetRet::Command(cmd.to_owned()),
             _ => WidgetRet::KeyIgnored,
         }
     }

--- a/crates/libtiny_tui/src/input_area/mod.rs
+++ b/crates/libtiny_tui/src/input_area/mod.rs
@@ -211,7 +211,7 @@ impl InputArea {
         }
     }
 
-    pub(crate) fn keypressed(&mut self, key_action: KeyAction) -> WidgetRet {
+    pub(crate) fn keypressed(&mut self, key_action: &KeyAction) -> WidgetRet {
         match key_action {
             KeyAction::InputSend => {
                 if self.current_buffer_len() > 0 {
@@ -330,9 +330,12 @@ impl InputArea {
             }
             KeyAction::Input(ch) => {
                 self.modify();
-                self.buffer.insert(self.cursor as usize, ch);
+                self.buffer.insert(self.cursor as usize, *ch);
                 self.inc_cursor();
                 WidgetRet::KeyHandled
+            }
+            KeyAction::RunIrcCommand(cmd) => {
+                WidgetRet::Command(cmd.to_owned())
             }
             _ => WidgetRet::KeyIgnored,
         }
@@ -777,18 +780,18 @@ mod tests {
     #[test]
     fn text_field_bug() {
         let mut text_field = InputArea::new(10, 50);
-        text_field.keypressed(KeyAction::Input('a'));
-        text_field.keypressed(KeyAction::Input(' '));
-        text_field.keypressed(KeyAction::Input('b'));
-        text_field.keypressed(KeyAction::Input(' '));
-        text_field.keypressed(KeyAction::Input('c'));
-        text_field.keypressed(KeyAction::InputSend);
-        text_field.keypressed(KeyAction::InputPrevEntry);
+        text_field.keypressed(&KeyAction::Input('a'));
+        text_field.keypressed(&KeyAction::Input(' '));
+        text_field.keypressed(&KeyAction::Input('b'));
+        text_field.keypressed(&KeyAction::Input(' '));
+        text_field.keypressed(&KeyAction::Input('c'));
+        text_field.keypressed(&KeyAction::InputSend);
+        text_field.keypressed(&KeyAction::InputPrevEntry);
         // this panics:
-        text_field.keypressed(KeyAction::InputMoveWordLeft);
+        text_field.keypressed(&KeyAction::InputMoveWordLeft);
         // a b ^c
         assert_eq!(text_field.cursor, 4);
-        text_field.keypressed(KeyAction::InputMoveWordRight);
+        text_field.keypressed(&KeyAction::InputMoveWordRight);
         assert_eq!(text_field.cursor, 5);
     }
 

--- a/crates/libtiny_tui/src/key_map.rs
+++ b/crates/libtiny_tui/src/key_map.rs
@@ -368,10 +368,9 @@ fn deser_keymap() {
         .insert(Key::Ctrl('a'), KeyAction::InputMoveCursStart);
     expect.0.insert(Key::Ctrl('e'), KeyAction::TabGoto('1'));
     expect.0.insert(Key::Char('a'), KeyAction::Input('b'));
-    expect.0.insert(
-        Key::Char('b'),
-        KeyAction::RunCommand("clear".to_string()),
-    );
+    expect
+        .0
+        .insert(Key::Char('b'), KeyAction::RunCommand("clear".to_string()));
 
     let key_map: KeyMap = serde_yaml::from_str(s).unwrap();
     assert_eq!(expect, key_map);

--- a/crates/libtiny_tui/src/key_map.rs
+++ b/crates/libtiny_tui/src/key_map.rs
@@ -31,7 +31,7 @@ pub(crate) enum KeyAction {
     MessagesScrollBottom,
 
     Input(char),
-    RunIrcCommand(String),
+    RunCommand(String),
     InputAutoComplete,
     InputNextEntry,
     InputPrevEntry,
@@ -68,7 +68,7 @@ impl Display for KeyAction {
             KeyAction::MessagesScrollTop => "messages_scroll_top",
             KeyAction::MessagesScrollBottom => "messages_scroll_bottom",
             KeyAction::Input(c) => return writeln!(f, "input_{}", c),
-            KeyAction::RunIrcCommand(string) => return writeln!(f, "run_irc_command_{}", string),
+            KeyAction::RunCommand(string) => return writeln!(f, "run_command_{}", string),
             KeyAction::InputAutoComplete => "input_auto_complete",
             KeyAction::InputNextEntry => "input_next_entry",
             KeyAction::InputPrevEntry => "input_prev_entry",
@@ -360,7 +360,7 @@ fn deser_keymap() {
     a: 
       input: b
     b:
-      run_irc_command: clear
+      run_command: clear
     "#;
     let mut expect = KeyMap(HashMap::new());
     expect
@@ -370,7 +370,7 @@ fn deser_keymap() {
     expect.0.insert(Key::Char('a'), KeyAction::Input('b'));
     expect.0.insert(
         Key::Char('b'),
-        KeyAction::RunIrcCommand("clear".to_string()),
+        KeyAction::RunCommand("clear".to_string()),
     );
 
     let key_map: KeyMap = serde_yaml::from_str(s).unwrap();

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -178,7 +178,7 @@ async fn input_handler<S>(
                         return;
                     }
                     TUIRet::KeyHandled | TUIRet::KeyIgnored(_) | TUIRet::EventIgnored(_) => {}
-                    TUIRet::KeyCommand{cmd, from} => {
+                    TUIRet::KeyCommand { cmd, from } => {
                         let result = tui.borrow_mut().try_handle_cmd(&cmd, &from);
                         match result {
                             CmdResult::Ok => {}

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -130,7 +130,7 @@ impl MessagingUI {
         self.msg_area.draw(tb, colors, pos_x, pos_y);
     }
 
-    pub(crate) fn keypressed(&mut self, key_action: KeyAction) -> WidgetRet {
+    pub(crate) fn keypressed(&mut self, key_action: &KeyAction) -> WidgetRet {
         match key_action {
             KeyAction::Exit => {
                 self.toggle_exit_dialogue();

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -33,6 +33,11 @@ pub(crate) enum TUIRet {
     KeyIgnored(Key),
     EventIgnored(Event),
 
+    KeyCommand {
+        cmd: String,
+        from: MsgSource,
+    },
+
     /// INVARIANT: The vec will have at least one char.
     // Can't make MsgSource a ref because of this weird error:
     // https://users.rust-lang.org/t/borrow-checker-bug/5165
@@ -670,9 +675,13 @@ impl TUI {
         });
 
         if let Some(key_action) = key_action {
-            match self.tabs[self.active_idx].widget.keypressed(key_action) {
+            match self.tabs[self.active_idx].widget.keypressed(&key_action) {
                 WidgetRet::KeyHandled => TUIRet::KeyHandled,
                 WidgetRet::KeyIgnored => self.handle_keypress(key, key_action, rcv_editor_ret),
+                WidgetRet::Command(cmd) => TUIRet::KeyCommand {
+                    cmd,
+                    from: self.tabs[self.active_idx].src.clone(),
+                },
                 WidgetRet::Input(input) => TUIRet::Input {
                     msg: input,
                     from: self.tabs[self.active_idx].src.clone(),

--- a/crates/libtiny_tui/src/widget.rs
+++ b/crates/libtiny_tui/src/widget.rs
@@ -7,6 +7,9 @@ pub(crate) enum WidgetRet {
 
     /// An input is submitted.
     Input(Vec<char>),
+   
+    /// A command is ran
+    Command(String),
 
     /// Remove the widget. E.g. close the tab, hide the dialogue etc.
     Remove,

--- a/crates/libtiny_tui/src/widget.rs
+++ b/crates/libtiny_tui/src/widget.rs
@@ -7,7 +7,7 @@ pub(crate) enum WidgetRet {
 
     /// An input is submitted.
     Input(Vec<char>),
-   
+
     /// A command is ran
     Command(String),
 


### PR DESCRIPTION
Allows the user to specify a config of this sort:
```yaml
key_map:
  ctrl_d:
    run_command: quit
```

Fixes #403