### PR TITLE
Replace clap with a simple hand-written arg parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,17 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,31 +252,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -587,15 +551,6 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -641,7 +596,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -953,12 +908,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "parking"
@@ -1373,12 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,15 +1403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,12 +1413,6 @@ dependencies = [
  "redox_syscall 0.2.16",
  "redox_termios",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1537,7 +1465,6 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 name = "tiny"
 version = "0.11.0"
 dependencies = [
- "clap",
  "dirs",
  "env_logger",
  "libtiny_client",
@@ -1820,15 +1747,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/tiny/Cargo.toml
+++ b/crates/tiny/Cargo.toml
@@ -15,7 +15,6 @@ tls-rustls = ["libtiny_client/tls-rustls"]
 desktop-notifications = ["libtiny_tui/desktop-notifications"]
 
 [dependencies]
-clap = { version = "3.1", features = ["cargo"] }
 dirs = "4.0"
 env_logger = { version = "0.9", default-features = false }
 libtiny_client = { path = "../libtiny_client", default-features = false }

--- a/crates/tiny/src/cli.rs
+++ b/crates/tiny/src/cli.rs
@@ -46,6 +46,13 @@ pub(crate) fn parse() -> Args {
             }
         }
 
+        if arg.starts_with('-') {
+            eprintln!("Error: Found argument '{arg}' which wasn't expected");
+            eprintln!();
+            eprintln!("For more information try --help");
+            std::process::exit(1);
+        }
+
         servers.push(arg);
     }
 

--- a/crates/tiny/src/cli.rs
+++ b/crates/tiny/src/cli.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use clap::{crate_authors, crate_description, crate_name, crate_version, Arg, Command};
-
 /// Command line arguments.
 #[derive(Debug)]
 pub(crate) struct Args {
@@ -15,48 +13,73 @@ pub(crate) struct Args {
     pub(crate) config_path: Option<PathBuf>,
 }
 
-/// Parses command line arguments.
+/// Parses command line arguments and handles `--version` and `--help`.
 pub(crate) fn parse() -> Args {
-    let mut version = crate_version!().to_owned();
-    let commit_hash = env!("GIT_HASH");
-    if !commit_hash.is_empty() {
-        version = format!("{} ({})", version, commit_hash);
+    let mut servers: Vec<String> = Vec::new();
+    let mut config_path: Option<PathBuf> = None;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "-V" || arg == "--version" {
+            print_version();
+            std::process::exit(0);
+        }
+
+        if arg == "-h" || arg == "--help" {
+            print_help();
+            std::process::exit(0);
+        }
+
+        if arg == "-c" || arg == "--config" {
+            match args.next() {
+                Some(path) => {
+                    config_path = Some(path.into());
+                    continue;
+                }
+
+                None => {
+                    eprintln!("Error: The argument '--config <FILE>' requires a file path but none was supplied");
+                    eprintln!();
+                    eprintln!("For more information try --help");
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        servers.push(arg);
     }
-
-    let m = Command::new(crate_name!())
-        .version(version.as_str())
-        .about(crate_description!())
-        .author(crate_authors!())
-        .arg(
-            Arg::new("config")
-                .short('c')
-                .long("config")
-                .value_name("FILE")
-                .help("Use this config file")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::new("servers")
-                .multiple_values(true)
-                .takes_value(true)
-                .help(
-                    "Servers to connect. For example, `tiny foo bar` \
-                     connects to servers whose names contain \"foo\" OR \
-                     \"bar\".",
-                )
-                .next_line_help(false),
-        )
-        .get_matches();
-
-    let servers = match m.values_of("servers") {
-        None => vec![],
-        Some(vals) => vals.map(str::to_owned).collect(),
-    };
-
-    let config_path = m.value_of("config").map(PathBuf::from);
 
     Args {
         servers,
         config_path,
     }
+}
+
+fn print_version() {
+    let crate_version = env!("CARGO_PKG_VERSION");
+    let commit_hash = env!("GIT_HASH");
+    println!("tiny {crate_version} ({commit_hash})");
+}
+
+fn print_help() {
+    print_version();
+    let crate_authors = env!("CARGO_PKG_AUTHORS");
+    let crate_description = env!("CARGO_PKG_DESCRIPTION");
+    println!(
+        "\
+{crate_authors}
+{crate_description}
+
+USAGE:
+    tiny [OPTIONS] [servers]
+
+ARGS:
+    <servers>       Servers to connect. For example, `tiny foo bar` connects to servers whose
+                    names contain \"foo\" OR \"bar\".
+
+OPTIONS:
+    -c, --config <FILE>    Use this config file
+    -h, --help             Print help information
+    -V, --version          Print version information",
+    )
 }


### PR DESCRIPTION
clap is too heavyweight for what tiny needs. Replacing it with a simple hand-written parser reduces debug binary sizes a constant 14 MiB (!), and release binary sizes ~400 KiB.

- Default build, debug:
  - Before: 73M
  - After: 59M
  - Diff: -14M, -29%

- Default build, release:
  - Before: 6.4M
  - After: 6.0M
  - Diff: -0.4M, -6%

- Native TLS build, release:
  - Before: 4.6M
  - After: 4.2M
  - Diff: -0.4M, -8%

Also saves ~10s build time and ~3s `cargo check` time.

Error messages and the help message is copied from what clap printed and modified.