### PR TITLE
Add tab_joinpart to default config

### DIFF
--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -164,6 +164,10 @@ colors:
         bg: default
         attrs: [bold]
 
+    tab_joinpart:
+        fg: 11
+        bg: default
+
 # Custom key mappings. Syntax is:
 #
 # [key_name]: [key_action]


### PR DESCRIPTION
So that users can easily find the option to tweak it.

Related to https://github.com/osa1/tiny/issues/262 c6d20b68 introduced this option.