### PR TITLE
README.md: replace freenode reference with libera

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ this config:
 
 ```yaml
 servers:
-    - addr: chat.freenode.net
+    - addr: irc.libera.chat
       ...
 
     - addr: irc.gnome.org
@@ -141,7 +141,7 @@ servers:
 ```
 
 By default tiny connects to both servers. You can connect to only the first
-server by passing `freenode` as a command line argument.
+server by passing `libera` as a command line argument.
 
 You can use `--config <path>` to specify your config file location.
 


### PR DESCRIPTION
Freenode is dead. Many open-source projects left the network due to the 2021 situation (of hostile takeover, etc.) and have since migrated to Libera.