### PR TITLE
PKGBUILD: refactor, improve, and sync changes with the version found in AUR git

### DIFF
--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -10,8 +10,8 @@ arch=(x86_64)
 url=https://github.com/osa1/tiny
 license=(MIT)
 
-depends=(openssl dbus)
-makedepends=(git rust)
+depends=(dbus)
+makedepends=(git cargo)
 provides=(${pkgname%-git})
 conflicts=(${pkgname%-git})
 source=(git+$url)

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -1,25 +1,27 @@
-# Maintainer: Eduardo Flores <edfloreshz@gmail.com>
-
+# Maintainer: Nick Econopouly <wry at mm dot st>
 pkgname=tiny-irc-client-git
-pkgver="0.9.0"
+pkgver="0.10.0"
 pkgrel=1
-pkgdesc="A console IRC client written in Rust"
+pkgdesc="A console IRC client"
 arch=('x86_64')
-provides=('tiny')
+provides=('tiny-irc-client')
+conflicts=('tiny-irc-client')
 url="https://github.com/osa1/tiny"
 license=('MIT')
 depends=('openssl' 'dbus')
-makedepends=('git' 'rust' 'cargo')
-source=("git+$url#commit=5e5c90c8f6b85b5ba38c974ed8113beef0e916ed") # tag: v0.9.0
+makedepends=('git' 'rust')
+source=(git+$url)
 sha512sums=(SKIP)
 
 build() {
-          cargo build \
-            --manifest-path "$srcdir/tiny/Cargo.toml" \
-            --release
+
+    # build tiny
+    cd tiny
+    cargo install --path crates/tiny --features=desktop-notifications
 }
 
 package() {
-          install -Dm755 tiny/target/release/tiny "$pkgdir/usr/bin/tiny"
-          install -Dm644 tiny/LICENSE "$pkgdir/usr/share/licenses/tiny/LICENSE"
+    cd tiny
+    install -Dm755 target/release/tiny "$pkgdir/usr/bin/tiny"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/tiny/LICENSE"
 }

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -19,6 +19,12 @@ sha512sums=(SKIP)
 
 _pkgname=${pkgname%-irc-client-git}
 
+pkgver() {
+    cd $_pkgname
+    git describe --tags --long | \
+        sed -e 's/\([^-]*-\)g/r\1/' -e 's/-/./g' -e 's/^v//'
+}
+
 build() {
     cd $_pkgname
     cargo install --path crates/$_pkgname --features=desktop-notifications

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -5,7 +5,7 @@
 pkgname=tiny-irc-client-git
 pkgver=0.10.0
 pkgrel=1
-pkgdesc='A console IRC client'
+pkgdesc='A terminal IRC client written in Rust'
 arch=(x86_64)
 url=https://github.com/osa1/tiny
 license=(MIT)

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -3,28 +3,29 @@
 # Contributor: Nick Econopouly <wry at mm dot st>
 
 pkgname=tiny-irc-client-git
-pkgver="0.10.0"
+pkgver=0.10.0
 pkgrel=1
-pkgdesc="A console IRC client"
-arch=('x86_64')
-provides=('tiny-irc-client')
-conflicts=('tiny-irc-client')
-url="https://github.com/osa1/tiny"
-license=('MIT')
-depends=('openssl' 'dbus')
-makedepends=('git' 'rust')
+pkgdesc='A console IRC client'
+arch=(x86_64)
+url=https://github.com/osa1/tiny
+license=(MIT)
+
+depends=(openssl dbus)
+makedepends=(git rust)
+provides=(${pkgname%-git})
+conflicts=(${pkgname%-git})
 source=(git+$url)
 sha512sums=(SKIP)
 
-build() {
+_pkgname=${pkgname%-irc-client-git}
 
-    # build tiny
-    cd tiny
-    cargo install --path crates/tiny --features=desktop-notifications
+build() {
+    cd $_pkgname
+    cargo install --path crates/$_pkgname --features=desktop-notifications
 }
 
 package() {
-    cd tiny
-    install -Dm755 target/release/tiny "$pkgdir/usr/bin/tiny"
-    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/tiny/LICENSE"
+    cd $_pkgname
+    install -Dm755 target/release/$_pkgname "$pkgdir"/usr/bin/$_pkgname
+    install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$_pkgname/LICENSE
 }

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -1,4 +1,7 @@
-# Maintainer: Nick Econopouly <wry at mm dot st>
+# Maintainer: Jonathan Kirszling <jonathan.kirszling at runbox dot com>
+# Maintainer: Ralph Torres <mail at ralphptorr dot es>
+# Contributor: Nick Econopouly <wry at mm dot st>
+
 pkgname=tiny-irc-client-git
 pkgver="0.10.0"
 pkgrel=1

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -28,4 +28,9 @@ package() {
     cd $_pkgname
     install -Dm755 target/release/$_pkgname "$pkgdir"/usr/bin/$_pkgname
     install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$_pkgname/LICENSE
+    install -Dm644 crates/$_pkgname/config.yml \
+        "$pkgdir"/usr/share/$_pkgname/config.yml
+    mkdir -p "$pkgdir"/usr/share/doc/$_pkgname
+    install -Dm644 ARCHITECTURE.md CHANGELOG.md README.md \
+        "$pkgdir"/usr/share/doc/$_pkgname
 }

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Nick Econopouly <wry at mm dot st>
 
 pkgname=tiny-irc-client-git
-pkgver=0.10.0
+pkgver=0.11.0.r18.e125c77
 pkgrel=1
 pkgdesc='A terminal IRC client written in Rust'
 arch=(x86_64)


### PR DESCRIPTION
This patch mirrors the PKGBUILD from AUR git, refactors, and improves it via the following commits. These commits are already present in the AUR git so anyone can test this script by installing tiny-irc-client-git.

Context: Prior to these commits, this script was not updated since 2021/11.  I reached out to the maintainers to suggest improvements. They mentioned they no longer use tiny then gave me the blessing to maintain the package myself.