### PR TITLE
Update CI scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,13 +130,13 @@ jobs:
             target: x86_64-unknown-linux-musl
             override: true
 
-      - name: Make statically linked executable
+      - name: '[Linux] Make statically linked executable'
         run: |
           RUST_BACKTRACE=1 \
             cargo build --release --verbose --target=x86_64-unknown-linux-musl
 
   Linux_static_build_desktop_notifications:
-    name: Make statically linked executable (desktop notifications)
+    name: '[Linux] Make statically linked executable (desktop notifications)'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,39 @@ jobs:
         run: |
           cargo test --no-default-features \
             --features "tls-native desktop-notifications"
+
+  # Updating dependencies can break the static build.
+  Linux_static_build_default:
+    name: Make statically linked executable (default)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install native dependencies
+        run: |
+            sudo apt-get update
+            sudo apt-get install libdbus-1-dev pkg-config libssl-dev \
+                musl musl-dev musl-tools
+
+      - name: Make statically linked executable
+        run: |
+          RUST_BACKTRACE=1 \
+            cargo build --release --verbose --target=x86_64-unknown-linux-musl
+
+  Linux_static_build_desktop_notifications:
+    name: Make statically linked executable (desktop notifications)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install native dependencies
+        run: |
+            sudo apt-get update
+            sudo apt-get install libdbus-1-dev pkg-config libssl-dev \
+                musl musl-dev musl-tools
+
+      - name: Make statically linked executable
+        run: |
+          RUST_BACKTRACE=1 \
+            cargo build --release --verbose --target=x86_64-unknown-linux-musl \
+              --features=desktop-notifications

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,13 @@ jobs:
             sudo apt-get install libdbus-1-dev pkg-config libssl-dev \
                 musl musl-dev musl-tools
 
+      - name: Get stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            target: x86_64-unknown-linux-musl
+            override: true
+
       - name: Make statically linked executable
         run: |
           RUST_BACKTRACE=1 \
@@ -139,6 +146,13 @@ jobs:
             sudo apt-get update
             sudo apt-get install libdbus-1-dev pkg-config libssl-dev \
                 musl musl-dev musl-tools
+
+      - name: Get stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            target: x86_64-unknown-linux-musl
+            override: true
 
       - name: Make statically linked executable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Check_formatting:
     name: 'Check formatting'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -21,7 +21,7 @@ jobs:
 
   Linux_default:
     name: '[Linux, default] Build and test'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -42,7 +42,7 @@ jobs:
 
   Linux_native_tls_notif:
     name: '[Linux, native TLS + notifications] Build and test'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   make_release:
     name: Make release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -40,34 +40,32 @@ jobs:
       - name: Make release tarball (default)
         run: |
           (cd crates/tiny && cargo build --release --verbose)
-          tar -C target/release -czvf tiny-ubuntu-20.04.tar.gz tiny
+          tar -C target/release -czvf tiny-ubuntu-22.04.tar.gz tiny
 
       - name: Make release tarball (default, statically linked)
         run: |
           (cd crates/tiny && RUST_BACKTRACE=1 \
             cargo build --release --verbose --target=x86_64-unknown-linux-musl)
           tar -C target/x86_64-unknown-linux-musl/release \
-            -czvf tiny-ubuntu-20.04-static.tar.gz tiny
+            -czvf tiny-ubuntu-22.04-static.tar.gz tiny
 
       - name: Make release tarball (libssl)
         run: |
           (cd crates/tiny && cargo build --release --verbose \
             --no-default-features --features="tls-native")
-          tar -C target/release -czvf tiny-ubuntu-20.04-libssl.tar.gz tiny
+          tar -C target/release -czvf tiny-ubuntu-22.04-libssl.tar.gz tiny
 
       - name: Make release tarball (libdbus)
         run: |
           (cd crates/tiny && cargo build --release --verbose \
             --no-default-features --features="tls-rustls desktop-notifications")
-          tar -C target/release -czvf tiny-ubuntu-20.04-dbus.tar.gz tiny
+          tar -C target/release -czvf tiny-ubuntu-22.04-dbus.tar.gz tiny
 
       - name: Make release tarball (libssl + libdbus)
         run: |
           (cd crates/tiny && cargo build --release --verbose \
             --no-default-features --features="tls-native desktop-notifications")
-          tar -C target/release -czvf tiny-ubuntu-20.04-libssl-dbus.tar.gz tiny
-
-      # TODO: Can I not do this in one step?
+          tar -C target/release -czvf tiny-ubuntu-22.04-libssl-dbus.tar.gz tiny
 
       - name: Upload executable (1/5)
         uses: actions/upload-release-asset@v1.0.1
@@ -75,8 +73,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tiny-ubuntu-20.04.tar.gz
-          asset_name: tiny-ubuntu-20.04.tar.gz
+          asset_path: tiny-ubuntu-22.04.tar.gz
+          asset_name: tiny-ubuntu-22.04.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload executable (2/5)
@@ -85,8 +83,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tiny-ubuntu-20.04-static.tar.gz
-          asset_name: tiny-ubuntu-20.04-static.tar.gz
+          asset_path: tiny-ubuntu-22.04-static.tar.gz
+          asset_name: tiny-ubuntu-22.04-static.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload executable (3/5)
@@ -95,8 +93,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tiny-ubuntu-20.04-libssl.tar.gz
-          asset_name: tiny-ubuntu-20.04-libssl.tar.gz
+          asset_path: tiny-ubuntu-22.04-libssl.tar.gz
+          asset_name: tiny-ubuntu-22.04-libssl.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload executable (4/5)
@@ -105,8 +103,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tiny-ubuntu-20.04-dbus.tar.gz
-          asset_name: tiny-ubuntu-20.04-dbus.tar.gz
+          asset_path: tiny-ubuntu-22.04-dbus.tar.gz
+          asset_name: tiny-ubuntu-22.04-dbus.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload executable (5/5)
@@ -115,6 +113,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tiny-ubuntu-20.04-libssl-dbus.tar.gz
-          asset_name: tiny-ubuntu-20.04-libssl-dbus.tar.gz
+          asset_path: tiny-ubuntu-22.04-libssl-dbus.tar.gz
+          asset_name: tiny-ubuntu-22.04-libssl-dbus.tar.gz
           asset_content_type: application/gzip


### PR DESCRIPTION
- Update Ubuntu from 20.04 to 22.04.
- Test statically linked builds in PRs to make sure we don't break the build when updating dependencies.