### PR TITLE
Add user blocking feature

### DIFF
--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -4,7 +4,7 @@
 use libtiny_common::{ChanName, ChanNameRef};
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use termbox_simple::*;
@@ -33,7 +33,7 @@ pub(crate) struct Config {
     pub(crate) key_map: Option<KeyMap>,
 
     #[serde(default)]
-    pub(crate) blocked_users: Vec<String>,
+    pub(crate) blocked_users: HashSet<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]

--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -31,6 +31,9 @@ pub(crate) struct Config {
 
     #[serde(default)]
     pub(crate) key_map: Option<KeyMap>,
+
+    #[serde(default)]
+    pub(crate) blocked_users: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]

--- a/crates/libtiny_tui/src/lib.rs
+++ b/crates/libtiny_tui/src/lib.rs
@@ -303,4 +303,11 @@ impl TUI {
             .upgrade()
             .map(|tui| tui.borrow().current_tab().clone())
     }
+
+    pub fn check_blocked(&self, user: &String) -> bool {
+        match self.inner.upgrade() {
+            Some(tui) => tui.borrow().check_blocked(user),
+            None => false,
+        }
+    }
 }

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -8,7 +8,7 @@
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::str::{self, SplitWhitespace};
 use time::Tm;
@@ -110,7 +110,7 @@ pub struct TUI {
     tab_configs: TabConfigs,
 
     /// List of blocked users
-    blocked_users: Vec<String>,
+    blocked_users: HashSet<String>,
 }
 
 pub(crate) enum CmdResult {
@@ -178,7 +178,7 @@ impl TUI {
             key_map: KeyMap::default(),
             config_path,
             tab_configs: TabConfigs::default(),
-            blocked_users: Vec::default(),
+            blocked_users: HashSet::default(),
         };
 
         // Init "mentions" tab. This needs to happen right after creating the TUI to be able to

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -108,6 +108,9 @@ pub struct TUI {
 
     /// TabConfig settings loaded from config file
     tab_configs: TabConfigs,
+
+    /// List of blocked users
+    blocked_users: Vec<String>,
 }
 
 pub(crate) enum CmdResult {
@@ -175,6 +178,7 @@ impl TUI {
             key_map: KeyMap::default(),
             config_path,
             tab_configs: TabConfigs::default(),
+            blocked_users: Vec::default(),
         };
 
         // Init "mentions" tab. This needs to happen right after creating the TUI to be able to
@@ -365,11 +369,13 @@ impl TUI {
                 max_nick_length,
                 key_map,
                 layout,
+                blocked_users,
                 ..
             } = config;
             self.set_colors(colors);
             self.scrollback = scrollback.max(1);
             self.key_map.load(&key_map.unwrap_or_default());
+            self.blocked_users = blocked_users;
             if let Some(layout) = layout {
                 match layout {
                     crate::config::Layout::Compact => self.msg_layout = Layout::Compact,
@@ -560,6 +566,11 @@ impl TUI {
             }
         }
         self.fix_scroll_after_close();
+    }
+
+    /// Checks if user is on the block list
+    pub(crate) fn check_blocked(&self, user: &String) -> bool {
+        self.blocked_users.contains(user)
     }
 
     pub(crate) fn handle_input_event(

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -66,6 +66,9 @@ defaults:
 # Location for chat logs.
 log_dir: "{}"
 
+# Hides incoming messages from hostmasks in the list.
+# blocked_users: []
+
 # Limits the maximum number of messages stored in each tab. Default is
 # unlimited.
 # scrollback: 512

--- a/crates/tiny/src/conn.rs
+++ b/crates/tiny/src/conn.rs
@@ -173,6 +173,18 @@ fn handle_irc_msg(ui: &UI, client: &dyn Client, msg: wire::Msg) {
                 User { ref nick, .. } | Ambiguous(ref nick) => nick,
             };
 
+            let sender_hostmask = match pfx {
+                User { ref user, .. } => Some(user),
+                _ => None,
+            };
+
+            if let Some(sender_hostmask_str) = sender_hostmask {
+                if ui.check_blocked(sender_hostmask_str) {
+                    // Blocked
+                    return;
+                }
+            }
+
             if ctcp == Some(wire::CTCP::Version) {
                 let msg_target = if ui.user_tab_exists(serv, sender) {
                     MsgTarget::User { serv, nick: sender }

--- a/crates/tiny/src/ui.rs
+++ b/crates/tiny/src/ui.rs
@@ -86,6 +86,7 @@ impl UI {
     delegate_ui!(set_nick(serv: &str, nick: &str,));
     delegate_ui!(set_tab_style(style: TabStyle, target: &MsgTarget,));
     delegate_ui!(user_tab_exists(serv_name: &str, nick: &str,) -> bool);
+    delegate_ui!(check_blocked(user: &String,) -> bool);
     delegate_ui!(get_tab_config(serv_name: &str, chan_name: Option<&ChanNameRef>,) -> TabConfig);
     delegate_ui!(set_tab_config(
         serv_name: &str,


### PR DESCRIPTION
This pull request addresses [Issue #369](https://github.com/osa1/tiny/issues/369) and implements the requested feature.

To block a user, add this line to the config:
```
blocked_users: ["~user@example"]
```

Inside the blocked_users list, add the hostmasks of the users you would like to block.

If this gets approved, we could eventually expand on the block function by implementing features such as:

- Regex matching (e.g. "~user@*")
- Separate .yml file for the blocked users
- /block, /unblock commands