### PR TITLE
Improve handling of IRC color code (0x03) without colors afterwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Improve nick matching to avoid highlighting message incorrectly. (#430)
+- Fix resetting message color when a color prefix (0x03) is not followed by a
+  color code. (#434)
 
 # 2024/01/01: 0.12.0
 

--- a/crates/libtiny_tui/src/msg_area/line.rs
+++ b/crates/libtiny_tui/src/msg_area/line.rs
@@ -152,7 +152,11 @@ impl Line {
                         self.set_message_style(SegStyle::Fixed(Style { fg: bg, bg: fg }));
                     }
                 }
-                IrcFormatEvent::Reset => {
+                // TODO: ResetColors should only reset the colors and not the formatting.
+                // However we don't store the current formatting and we can't apply formatting to
+                // a color from the current color scheme (e.g. `SegStyle::UserMsg`). For now reset
+                // the colors and formatting.
+                IrcFormatEvent::ResetColors | IrcFormatEvent::Reset => {
                     self.set_message_style(SegStyle::UserMsg);
                 }
             }


### PR DESCRIPTION
According to [1], a `0x03` without a color code following should reset the current bg and fg colors.

We can't reset just the colors without also resetting the formatting, for now reset colors + formatting.

Fixes #434.