### PR TITLE
Added support for `ctrl_h` and `ctrl_i` in keymap config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   color code. (#434)
 - Refactor an internal macro to make tiny builds deterministic, allowing
   reproducible builds. (#437)
+- Key bindings for `ctrl_i` and `ctrl_[` in the config file are no longer
+  ignored and are now synonymous with `tab` and `esc`. (#444)
+- The keystrokes `ctrl_h` and `backspace` can now be distinguished, which
+  allows the user to define separate key bindings in the config tile. (#445)
 
 # 2024/01/01: 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Key bindings for `ctrl_i` and `ctrl_[` in the config file are no longer
+  ignored and are now synonymous with `tab` and `esc`. (#444)
+- The keystrokes `ctrl_h` and `backspace` can now be distinguished, which
+  allows the user to define separate key bindings in the config file. (#445)
+
 # 2025/01/01: 0.13.0
 
 - Improve nick matching to avoid highlighting message incorrectly. (#430)
@@ -5,10 +12,6 @@
   color code. (#434)
 - Refactor an internal macro to make tiny builds deterministic, allowing
   reproducible builds. (#437)
-- Key bindings for `ctrl_i` and `ctrl_[` in the config file are no longer
-  ignored and are now synonymous with `tab` and `esc`. (#444)
-- The keystrokes `ctrl_h` and `backspace` can now be distinguished, which
-  allows the user to define separate key bindings in the config tile. (#445)
 
 # 2024/01/01: 0.12.0
 

--- a/crates/libtiny_tui/src/key_map.rs
+++ b/crates/libtiny_tui/src/key_map.rs
@@ -213,7 +213,13 @@ impl<'de> Deserialize<'de> for MappedKey {
                                 Key::CtrlF(f_key)
                             } else {
                                 match single_key(k2)? {
-                                    'h' => Key::Backspace,
+                                    // NOTE: The following special mappings are needed
+                                    // because, e.g., `Key::Ctrl('i')` is never generated
+                                    // by `term_input` since `ctrl_i` and `tab` send
+                                    // identical bytes and hence cannot be distinguished
+                                    // in a terminal app. Having the special mapping here
+                                    // allows the user to define a working key binding for
+                                    // `ctrl_i`, which would otherwise be ignored.
                                     'i' => Key::Tab,
                                     '[' => Key::Esc,
                                     other => Key::Ctrl(other),

--- a/crates/libtiny_tui/src/key_map.rs
+++ b/crates/libtiny_tui/src/key_map.rs
@@ -212,7 +212,12 @@ impl<'de> Deserialize<'de> for MappedKey {
                             } else if let Some(f_key) = parse_f_key(k2) {
                                 Key::CtrlF(f_key)
                             } else {
-                                Key::Ctrl(single_key(k2)?)
+                                match single_key(k2)? {
+                                    'h' => Key::Backspace,
+                                    'i' => Key::Tab,
+                                    '[' => Key::Esc,
+                                    other => Key::Ctrl(other),
+                                }
                             }
                         }
                         "shift" => {


### PR DESCRIPTION
I ran into this problem while trying to define a key binding for `ctrl_h`. Neither
did it work, nor did I get any error or warning. A quick search in the source
code revealed that the corresponding key strokes are represented as `Key::Backspace`
whereas the key binding itself is represented as `Key::Ctrl('h')`. I changed the
latter to be represented as `Key::Backspace` too, which fixes the issue. I included
a similar fix for `ctrl_i` (and also `ctrl_[`).