### PR TITLE
Add 'user' option for server

### DIFF
--- a/crates/libtiny_client/examples/echo.rs
+++ b/crates/libtiny_client/examples/echo.rs
@@ -39,6 +39,7 @@ fn main() {
         port,
         tls: false,
         pass: None,
+        user: None,
         realname: "tiny echo bot".to_owned(),
         nicks: vec![nick],
         auto_join: chans,

--- a/crates/libtiny_client/src/lib.rs
+++ b/crates/libtiny_client/src/lib.rs
@@ -47,6 +47,10 @@ pub struct ServerInfo {
     /// Server password.
     pub pass: Option<String>,
 
+    /// The username parameter of the USER command sent to the server at the beginning of the connection.
+    /// When not provided, the first nick in nicks is used as the username.
+    pub user: Option<String>,
+
     pub realname: String,
 
     /// Nicks to select when logging in.

--- a/crates/libtiny_client/src/state.rs
+++ b/crates/libtiny_client/src/state.rs
@@ -254,8 +254,9 @@ impl StateInner {
         snd_irc_msg
             .try_send(wire::nick(&self.current_nick))
             .unwrap();
+        let user = self.server_info.user.as_ref().unwrap_or(&self.nicks[0]);
         snd_irc_msg
-            .try_send(wire::user(&self.nicks[0], &self.server_info.realname))
+            .try_send(wire::user(user, &self.server_info.realname))
             .unwrap();
     }
 

--- a/crates/libtiny_wire/src/lib.rs
+++ b/crates/libtiny_wire/src/lib.rs
@@ -23,8 +23,8 @@ pub fn quit(reason: Option<String>) -> String {
     }
 }
 
-pub fn user(hostname: &str, realname: &str) -> String {
-    format!("USER {hostname} 8 * :{realname}\r\n")
+pub fn user(user: &str, realname: &str) -> String {
+    format!("USER {user} 8 * :{realname}\r\n")
 }
 
 pub fn nick(arg: &str) -> String {

--- a/crates/tiny/config.yml
+++ b/crates/tiny/config.yml
@@ -3,6 +3,9 @@ servers:
     - addr: irc.oftc.net
       port: 6697
       tls: true
+      # Username parameter of USER command sent to the server at the beginning
+      # of connection. When not provided, first nick will be used instead
+      # user: username
       realname: yourname
       nicks: [tiny_user]
 

--- a/crates/tiny/src/cmd.rs
+++ b/crates/tiny/src/cmd.rs
@@ -269,6 +269,7 @@ fn connect_(
         addr: serv_name.to_owned(),
         port: serv_port,
         tls: defaults.tls,
+        user: None,
         realname: defaults.realname.clone(),
         pass: pass.map(str::to_owned),
         nicks: defaults.nicks.clone(),

--- a/crates/tiny/src/config.rs
+++ b/crates/tiny/src/config.rs
@@ -59,6 +59,11 @@ pub(crate) struct Server<P> {
     #[serde(default)]
     pub(crate) pass: Option<P>,
 
+    /// User name to be used in connection registration
+    /// If it is not specified, the first nick will be used instead
+    #[serde(default)]
+    pub(crate) user: Option<String>,
+
     /// Real name to be used in connection registration
     #[serde(deserialize_with = "deser_trimmed_str")]
     pub(crate) realname: String,
@@ -319,6 +324,7 @@ impl Config<PassOrCmd> {
                 port,
                 tls,
                 pass,
+                user,
                 realname,
                 nicks,
                 join,
@@ -363,6 +369,7 @@ impl Config<PassOrCmd> {
                 port,
                 tls,
                 pass,
+                user,
                 realname,
                 nicks,
                 join,
@@ -483,6 +490,7 @@ mod tests {
                 port: 123,
                 tls: false,
                 pass: None,
+                user: None,
                 realname: "".to_owned(),
                 nicks: vec!["".to_owned()],
                 join: vec![],

--- a/crates/tiny/src/main.rs
+++ b/crates/tiny/src/main.rs
@@ -163,6 +163,7 @@ fn run(
                 port: server.port,
                 tls,
                 pass: server.pass,
+                user: server.user,
                 realname: server.realname,
                 nicks: server.nicks,
                 auto_join: server.join.iter().map(|c| c.name().to_owned()).collect(),


### PR DESCRIPTION
ZNC uses 'user' as a way to specify what network to connect to if there are several networks configured. E.g. myspecialuser/oftc or myspecialuser/libera