### PR TITLE
disables default feature tokio-rustls

### DIFF
--- a/crates/libtiny_client/Cargo.toml
+++ b/crates/libtiny_client/Cargo.toml
@@ -22,5 +22,5 @@ rustls-native-certs = { version = "0.6", optional = true }
 rustls-pemfile = { version = "1.0.3", optional = true }
 tokio = { version = "1.17", default-features = false, features = ["net", "rt", "io-util", "macros"] }
 tokio-native-tls = { version = "0.3", optional = true }
-tokio-rustls = { version = "0.24", optional = true }
+tokio-rustls = { version = ">=0.24", optional = true, default-features = false, features = ["ring", "logging", "tls12"] }
 tokio-stream = { version = "0.1" }


### PR DESCRIPTION
Hi!
This patch aims to

reduce build issues on different architectures, ensure compatibility with the latest TLS version, and reduce the need for unnecessary features, reducing conflicts.


There are two missing that I don't think I need to send you.

Patch 004.skip-tests-error.patch
Due to version updates, I believe it caused these errors.

Patch 006.remove-dependencies-not-debian.patch
It was because the rustc_tools_util dependency isn't in Debian yet.

I'm already adding it to Debian; as soon as it is, I'll remove it.